### PR TITLE
[Feat] #74 - 코스 디테일 API 연결

### DIFF
--- a/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
+++ b/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		CEEC6B492961C5E200D00E1E /* SplashVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC6B482961C5E200D00E1E /* SplashVC.swift */; };
 		CEEC6B4B2961D89700D00E1E /* CustomNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC6B4A2961D89700D00E1E /* CustomNavigationBar.swift */; };
 		CEF3CD98296D63B9002723A1 /* CourseStorageRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF3CD97296D63B9002723A1 /* CourseStorageRouter.swift */; };
+		CEF3CD9A296DB305002723A1 /* CourseDetailResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF3CD99296DB305002723A1 /* CourseDetailResponseDto.swift */; };
 		DA20D847296697A600F1581F /* MyCourseSelectVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20D846296697A600F1581F /* MyCourseSelectVC.swift */; };
 		DA20D849296697B400F1581F /* CourseUploadVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20D848296697B400F1581F /* CourseUploadVC.swift */; };
 		DA20D84E2966A9B300F1581F /* CourseSearchVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20D84D2966A9B300F1581F /* CourseSearchVC.swift */; };
@@ -158,13 +159,8 @@
 		CE0C23782966D6AF00B45063 /* ViewPager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPager.swift; sourceTree = "<group>"; };
 		CE0D9FD229648DA300CEB5CD /* CustomAlertVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertVC.swift; sourceTree = "<group>"; };
 		CE10063929680C5700FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
-		CE10063B29680C6800FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
-		CE10063C29680C7000FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		CE10063D29680C8100FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		CE10063E29680C8800FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
-		CE10063F29680C9800FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
-		CE10064129680CA700FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
-		CE10064229680CAD00FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		CE10064329680CB400FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		CE10064429680CBC00FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		CE10064D29680D2500FD31FB /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
@@ -215,7 +211,6 @@
 		CE591E9D296D5140000FCBB3 /* RunningRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningRouter.swift; sourceTree = "<group>"; };
 		CE591EA0296D5EB5000FCBB3 /* PrivateCourseResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateCourseResponseDto.swift; sourceTree = "<group>"; };
 		CE6655BE295D82E200C64E12 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
-		CE6655C0295D82F000C64E12 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		CE6655C1295D82F700C64E12 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		CE6655C5295D83B700C64E12 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		CE6655C7295D849F00C64E12 /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
@@ -283,6 +278,7 @@
 		CEEC6B482961C5E200D00E1E /* SplashVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashVC.swift; sourceTree = "<group>"; };
 		CEEC6B4A2961D89700D00E1E /* CustomNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBar.swift; sourceTree = "<group>"; };
 		CEF3CD97296D63B9002723A1 /* CourseStorageRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseStorageRouter.swift; sourceTree = "<group>"; };
+		CEF3CD99296DB305002723A1 /* CourseDetailResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailResponseDto.swift; sourceTree = "<group>"; };
 		DA20D846296697A600F1581F /* MyCourseSelectVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCourseSelectVC.swift; sourceTree = "<group>"; };
 		DA20D848296697B400F1581F /* CourseUploadVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseUploadVC.swift; sourceTree = "<group>"; };
 		DA20D84D2966A9B300F1581F /* CourseSearchVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSearchVC.swift; sourceTree = "<group>"; };
@@ -816,6 +812,7 @@
 			isa = PBXGroup;
 			children = (
 				CE591E9B296D4F69000FCBB3 /* RunningRecordResonseDto.swift */,
+				CEF3CD99296DB305002723A1 /* CourseDetailResponseDto.swift */,
 			);
 			path = ResponseDto;
 			sourceTree = "<group>";
@@ -903,7 +900,6 @@
 				CE40BB292968083B0030ABCA /* MyPageRouter */,
 				CE40BB2A296808440030ABCA /* CourseDetailRouter */,
 				CE40BB2B296808500030ABCA /* RunningRouter */,
-				CE6655C0295D82F000C64E12 /* .gitkeep */,
 			);
 			path = Router;
 			sourceTree = "<group>";
@@ -1362,6 +1358,7 @@
 				CEC2A6902962B06C00160BF7 /* convertLocationObject.swift in Sources */,
 				CEC2A6852961F92C00160BF7 /* CustomButton.swift in Sources */,
 				CE6B63D3296725E6003F900F /* CourseListCVC.swift in Sources */,
+				CEF3CD9A296DB305002723A1 /* CourseDetailResponseDto.swift in Sources */,
 				CE29D584296416D800F47542 /* caculateStatusBarHeight.swift in Sources */,
 				CE66560C295D928300C64E12 /* setRootViewController.swift in Sources */,
 				CE6655D9295D871B00C64E12 /* URL+.swift in Sources */,

--- a/Runnect-iOS/Runnect-iOS/Network/Dto/CourseStorageDto/ResponseDto/PrivateCourseResponseDto.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Dto/CourseStorageDto/ResponseDto/PrivateCourseResponseDto.swift
@@ -18,7 +18,7 @@ struct PrivateCourseResponseDto: Codable {
 struct PrivateCourse: Codable {
     let id: Int
     let image, createdAt: String
-    let distance: Float?
+    let distance: String?
     let path: [[Double]]?
     let departure: PrivateCourseDeparture
 }

--- a/Runnect-iOS/Runnect-iOS/Network/Dto/RunningDto/ResponseDto/CourseDetailResponseDto.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Dto/RunningDto/ResponseDto/CourseDetailResponseDto.swift
@@ -1,0 +1,17 @@
+//
+//  CourseDetailResponseDto.swift
+//  Runnect-iOS
+//
+//  Created by sejin on 2023/01/10.
+//
+
+import Foundation
+
+typealias Course = PrivateCourse
+typealias CourseDeparture = PrivateCourseDeparture
+
+// MARK: - CourseDetailResponseDto
+
+struct CourseDetailResponseDto: Codable {
+    let course: [Course]
+}

--- a/Runnect-iOS/Runnect-iOS/Network/Dto/RunningDto/ResponseDto/CourseDetailResponseDto.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Dto/RunningDto/ResponseDto/CourseDetailResponseDto.swift
@@ -13,5 +13,5 @@ typealias CourseDeparture = PrivateCourseDeparture
 // MARK: - CourseDetailResponseDto
 
 struct CourseDetailResponseDto: Codable {
-    let course: [Course]
+    let course: Course
 }

--- a/Runnect-iOS/Runnect-iOS/Network/Model/CourseDrawingModel/DepartureLocationModel.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Model/CourseDrawingModel/DepartureLocationModel.swift
@@ -12,4 +12,12 @@ struct DepartureLocationModel {
     let departureAddress: String
     let latitude: String
     let longitude: String
+    
+    var region: String {
+        departureAddress.split(separator: " ").map {String($0)}[0]
+    }
+    
+    var city: String {
+        departureAddress.split(separator: " ").map {String($0)}[1]
+    }
 }

--- a/Runnect-iOS/Runnect-iOS/Network/Model/RunningModel/RunningModel.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Model/RunningModel/RunningModel.swift
@@ -15,6 +15,7 @@ struct RunningModel {
     var locations: [NMGLatLng]
     var distance: String?
     var pathImage: UIImage?
+    var imageUrl: String?
     var totalTime: Int?
     var region: String?
     var city: String?

--- a/Runnect-iOS/Runnect-iOS/Network/Model/RunningModel/RunningModel.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Model/RunningModel/RunningModel.swift
@@ -16,6 +16,8 @@ struct RunningModel {
     var distance: String?
     var pathImage: UIImage?
     var totalTime: Int?
+    var region: String?
+    var city: String?
     
     /// HH:MM:SS 형식으로 반환
     func getFormattedTotalTime() -> String? {

--- a/Runnect-iOS/Runnect-iOS/Network/Router/RunningRouter/RunningRouter.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Router/RunningRouter/RunningRouter.swift
@@ -11,6 +11,7 @@ import Moya
 
 enum RunningRouter {
     case recordRunning(param: RunningRecordRequestDto)
+    case getCourseDetail(courseId: Int)
 }
 
 extension RunningRouter: TargetType {
@@ -26,6 +27,8 @@ extension RunningRouter: TargetType {
         switch self {
         case .recordRunning:
             return "/record"
+        case .getCourseDetail(let courseId):
+            return "/course/detail/\(courseId)"
         }
     }
     
@@ -33,6 +36,8 @@ extension RunningRouter: TargetType {
         switch self {
         case .recordRunning:
             return .post
+        case .getCourseDetail:
+            return .get
         }
     }
     
@@ -44,12 +49,14 @@ extension RunningRouter: TargetType {
             } catch {
                 fatalError(error.localizedDescription)
             }
+        case .getCourseDetail:
+            return .requestPlain
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .recordRunning:
+        case .recordRunning, .getCourseDetail:
             return Config.headerWithDeviceId
         }
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDrawing/VC/CourseDrawingVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDrawing/VC/CourseDrawingVC.swift
@@ -173,7 +173,9 @@ extension CourseDrawingVC {
             let runningModel = RunningModel(courseId: courseId,
                                             locations: self.mapView.getMarkersLatLng(),
                                             distance: self.distanceLabel.text,
-                                            pathImage: self.pathImage)
+                                            pathImage: self.pathImage,
+                                            region: self.departureLocationModel?.region,
+                                            city: self.departureLocationModel?.city)
             countDownVC.setData(runningModel: runningModel)
             self.navigationController?.pushViewController(countDownVC, animated: true)
             alertVC.dismiss(animated: true)

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/VC/CourseStorageVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/VC/CourseStorageVC.swift
@@ -70,6 +70,7 @@ extension CourseStorageVC {
         privateCourseListView.cellDidTapped.sink { [weak self] index in
             guard let self = self else { return }
             let runningWaitingVC = RunningWaitingVC()
+            runningWaitingVC.setData(courseId: self.privateCourseList[index].id, publicCourseId: nil)
             runningWaitingVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(runningWaitingVC, animated: true)
         }.store(in: cancelBag)

--- a/Runnect-iOS/Runnect-iOS/Presentation/Running/VC/CountDownVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/Running/VC/CountDownVC.swift
@@ -80,6 +80,7 @@ extension CountDownVC {
 extension CountDownVC {
     private func setUI() {
         view.backgroundColor = .m1
+        self.navigationController?.isNavigationBarHidden = true
     }
     
     private func setLayout() {

--- a/Runnect-iOS/Runnect-iOS/Presentation/Running/VC/RunningRecordVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/Running/VC/RunningRecordVC.swift
@@ -137,6 +137,9 @@ extension RunningRecordVC {
         
         guard let region = runningModel.region, let city = runningModel.city else { return }
         self.departureInfoView.setDescriptionText(description: "\(region) \(city)")
+        
+        guard let imageUrl = runningModel.imageUrl else { return }
+        self.courseImageView.setImage(with: imageUrl)
     }
 }
 

--- a/Runnect-iOS/Runnect-iOS/Presentation/Running/VC/RunningRecordVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/Running/VC/RunningRecordVC.swift
@@ -134,6 +134,9 @@ extension RunningRecordVC {
         self.totalTimeStatsView.setStats(stats: runningModel.getFormattedTotalTime() ?? "00:00:00")
         self.averagePaceStatsView.setStats(stats: runningModel.getFormattedAveragePage() ?? "0'00''")
         self.courseImageView.image = runningModel.pathImage
+        
+        guard let region = runningModel.region, let city = runningModel.city else { return }
+        self.departureInfoView.setDescriptionText(description: "\(region) \(city)")
     }
 }
 


### PR DESCRIPTION
## 🌱 작업한 내용

- 코스 디테일 API 연결

## 🌱 PR Point

- 보관함에서 내가 그린 코스를 선택하면 API를 호출하여 해당 코스에 맞는 경로 데이터를 받아와 지도에 그려줍니다.
- 이 API 는 추후 다른 곳에서도 courseId를 가지고 경로 정보를 받아올 때 사용할 수 있습니다!

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|  API 연결  |  ![Simulator Screen Recording - iPhone 14 - 2023-01-11 at 00 48 22](https://user-images.githubusercontent.com/77267404/211598094-187d6ecf-594f-4a30-84ba-366d335f603f.gif)  |

## 📮 관련 이슈

- Resolved: #74 
