### PR TITLE
[Feat] #85 - 스크랩코스 API 연결

### DIFF
--- a/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
+++ b/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A3F67AE2296D33AC001598A2 /* MyPageDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F67AE1296D33AC001598A2 /* MyPageDto.swift */; };
 		A3F67AE4296D33E0001598A2 /* MyPageRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F67AE3296D33E0001598A2 /* MyPageRouter.swift */; };
 		A3F67AEA296E4936001598A2 /* ActivityRecordInfoDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F67AE9296E4936001598A2 /* ActivityRecordInfoDto.swift */; };
+		CE09037D296E9ED900BEA710 /* ScrapCourseResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE09037C296E9ED900BEA710 /* ScrapCourseResponseDto.swift */; };
 		CE0C23742966D62A00B45063 /* PagedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0C23732966D62A00B45063 /* PagedView.swift */; };
 		CE0C23772966D64D00B45063 /* PageCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0C23762966D64D00B45063 /* PageCVC.swift */; };
 		CE0C23792966D6AF00B45063 /* ViewPager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0C23782966D6AF00B45063 /* ViewPager.swift */; };
@@ -158,6 +159,7 @@
 		A3F67AE1296D33AC001598A2 /* MyPageDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageDto.swift; sourceTree = "<group>"; };
 		A3F67AE3296D33E0001598A2 /* MyPageRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageRouter.swift; sourceTree = "<group>"; };
 		A3F67AE9296E4936001598A2 /* ActivityRecordInfoDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRecordInfoDto.swift; sourceTree = "<group>"; };
+		CE09037C296E9ED900BEA710 /* ScrapCourseResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapCourseResponseDto.swift; sourceTree = "<group>"; };
 		CE0C23732966D62A00B45063 /* PagedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedView.swift; sourceTree = "<group>"; };
 		CE0C23762966D64D00B45063 /* PageCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageCVC.swift; sourceTree = "<group>"; };
 		CE0C23782966D6AF00B45063 /* ViewPager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPager.swift; sourceTree = "<group>"; };
@@ -831,6 +833,7 @@
 			children = (
 				CE591EA0296D5EB5000FCBB3 /* PrivateCourseResponseDto.swift */,
 				CECA695B296E61D6002AF05C /* PrivateCourseNotUploadedResponseDto.swift */,
+				CE09037C296E9ED900BEA710 /* ScrapCourseResponseDto.swift */,
 			);
 			path = ResponseDto;
 			sourceTree = "<group>";
@@ -1400,6 +1403,7 @@
 				CE3A53C5296C6017003D518C /* KeychainManager.swift in Sources */,
 				CE14677A2965A80700DCEA1B /* CustomBottomSheetVC.swift in Sources */,
 				CEEC6B4B2961D89700D00E1E /* CustomNavigationBar.swift in Sources */,
+				CE09037D296E9ED900BEA710 /* ScrapCourseResponseDto.swift in Sources */,
 				CE40BB2D296808B00030ABCA /* DepartureSearchingRouter.swift in Sources */,
 				CE15F5A4296C932E0023827C /* RunningModel.swift in Sources */,
 				CE17F02D2961BBA100E1DED0 /* ColorLiterals.swift in Sources */,

--- a/Runnect-iOS/Runnect-iOS/Global/UIComponents/CustomButton.swift
+++ b/Runnect-iOS/Runnect-iOS/Global/UIComponents/CustomButton.swift
@@ -38,6 +38,18 @@ extension CustomButton {
         return self
     }
     
+    @discardableResult
+    public func setTitle(title: String) -> Self {
+        self.setAttributedTitle(
+            NSAttributedString(
+                string: title,
+                attributes: [.font: UIFont.h5, .foregroundColor: UIColor.white]
+            ),
+            for: .normal
+        )
+        return self
+    }
+    
     /// 버튼의 backgroundColor, textColor 변경
     @discardableResult
     public func setColor(bgColor: UIColor, disableColor: UIColor, textColor: UIColor = .white) -> Self {

--- a/Runnect-iOS/Runnect-iOS/Global/UIComponents/ListEmptyView.swift
+++ b/Runnect-iOS/Runnect-iOS/Global/UIComponents/ListEmptyView.swift
@@ -78,7 +78,7 @@ extension ListEmptyView {
         self.backgroundColor = .clear
         
         self.descriptionLabel.text = description
-        self.bottomButton.titleLabel?.text = buttonTitle
+        self.bottomButton.setTitle(title: buttonTitle)
     }
     
     private func setLayout() {

--- a/Runnect-iOS/Runnect-iOS/Network/Dto/CourseStorageDto/ResponseDto/ScrapCourseResponseDto.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Dto/CourseStorageDto/ResponseDto/ScrapCourseResponseDto.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - ScrapCourseResponseDto
 
-struct ScrapCourseResponseDto {
+struct ScrapCourseResponseDto: Codable {
     let scraps: [ScrapCourse]
 
     enum CodingKeys: String, CodingKey {

--- a/Runnect-iOS/Runnect-iOS/Network/Dto/CourseStorageDto/ResponseDto/ScrapCourseResponseDto.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Dto/CourseStorageDto/ResponseDto/ScrapCourseResponseDto.swift
@@ -1,0 +1,33 @@
+//
+//  ScrapCourseResponseDto.swift
+//  Runnect-iOS
+//
+//  Created by sejin on 2023/01/11.
+//
+
+import Foundation
+
+// MARK: - ScrapCourseResponseDto
+
+struct ScrapCourseResponseDto {
+    let scraps: [ScrapCourse]
+
+    enum CodingKeys: String, CodingKey {
+        case scraps = "Scraps"
+    }
+}
+
+// MARK: - ScrapCourse
+
+struct ScrapCourse: Codable {
+    let id, publicCourseId, courseId: Int
+    let title: String
+    let image: String
+    let departure: ScrapCourseDeparture
+}
+
+// MARK: - ScrapCourseDeparture
+
+struct ScrapCourseDeparture: Codable {
+    let region, city: String
+}

--- a/Runnect-iOS/Runnect-iOS/Network/Router/CourseStorageRouter/CourseStorageRouter.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Router/CourseStorageRouter/CourseStorageRouter.swift
@@ -12,6 +12,7 @@ import Moya
 enum CourseStorageRouter {
     case getAllPrivateCourse
     case getPrivateCourseNotUploaded
+    case getScrapCourse
 }
 
 extension CourseStorageRouter: TargetType {
@@ -29,26 +30,28 @@ extension CourseStorageRouter: TargetType {
             return "/course/user"
         case .getPrivateCourseNotUploaded:
             return "/course/private/user"
+        case .getScrapCourse:
+            return "/scrap/user"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getAllPrivateCourse, .getPrivateCourseNotUploaded:
+        case .getAllPrivateCourse, .getPrivateCourseNotUploaded, .getScrapCourse:
             return .get
         }
     }
     
     var task: Moya.Task {
         switch self {
-        case .getAllPrivateCourse, .getPrivateCourseNotUploaded:
+        case .getAllPrivateCourse, .getPrivateCourseNotUploaded, .getScrapCourse:
             return .requestPlain
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .getAllPrivateCourse, .getPrivateCourseNotUploaded:
+        case .getAllPrivateCourse, .getPrivateCourseNotUploaded, .getScrapCourse:
             return Config.headerWithDeviceId
         }
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
@@ -11,6 +11,11 @@ import Then
 
 final class CourseDetailVC: UIViewController {
     
+    // MARK: - Properties
+    
+    private var courseId: Int?
+    private var publicCourseId: Int?
+    
     // MARK: - UI Components
     private lazy var navibar = CustomNavigationBar(self, type: .titleWithLeftButton)
     private lazy var middleScorollView = UIScrollView().then {
@@ -112,6 +117,11 @@ extension CourseDetailVC {
 // MARK: - Method
 
 extension CourseDetailVC {
+    func setCourseId(courseId: Int?, publicCourseId: Int?) {
+        self.courseId = courseId
+        self.publicCourseId = publicCourseId
+    }
+    
     private func setAddTarget() {
         likeButton.addTarget(self, action: #selector(likeButtonDidTap), for: .touchUpInside)
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/VC/CourseStorageVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/VC/CourseStorageVC.swift
@@ -22,6 +22,8 @@ final class CourseStorageVC: UIViewController {
     
     private var privateCourseList = [PrivateCourse]()
     
+    private var scrapCourseList = [ScrapCourse]()
+    
     // MARK: - UI Components
     
     private lazy var naviBar = CustomNavigationBar(self, type: .title).setTitle("보관함")
@@ -45,6 +47,7 @@ final class CourseStorageVC: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.getPrivateCourseList()
+        self.getScrapCourseList()
     }
 }
 
@@ -54,6 +57,11 @@ extension CourseStorageVC {
     private func setPrivateCourseData(courseList: [PrivateCourse]) {
         self.privateCourseList = courseList
         self.privateCourseListView.setData(courseList: courseList)
+    }
+    
+    private func setScrapCourseData(courseList: [ScrapCourse]) {
+        self.scrapCourseList = courseList
+        self.scrapCourseListView.setData(courseList: courseList)
     }
     
     private func bindUI() {
@@ -122,6 +130,34 @@ extension CourseStorageVC {
                         let responseDto = try result.map(BaseResponse<PrivateCourseResponseDto>.self)
                         guard let data = responseDto.data else { return }
                         self.setPrivateCourseData(courseList: data.courses)
+                    } catch {
+                        print(error.localizedDescription)
+                    }
+                }
+                if status >= 400 {
+                    print("400 error")
+                    self.showNetworkFailureToast()
+                }
+            case .failure(let error):
+                print(error.localizedDescription)
+                self.showNetworkFailureToast()
+            }
+        }
+    }
+    
+    private func getScrapCourseList() {
+        LoadingIndicator.showLoading()
+        courseStorageProvider.request(.getScrapCourse) { [weak self] response in
+            guard let self = self else { return }
+            LoadingIndicator.hideLoading()
+            switch response {
+            case .success(let result):
+                let status = result.statusCode
+                if 200..<300 ~= status {
+                    do {
+                        let responseDto = try result.map(BaseResponse<ScrapCourseResponseDto>.self)
+                        guard let data = responseDto.data else { return }
+                        self.setScrapCourseData(courseList: data.scraps)
                     } catch {
                         print(error.localizedDescription)
                     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/VC/CourseStorageVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/VC/CourseStorageVC.swift
@@ -86,6 +86,8 @@ extension CourseStorageVC {
         scrapCourseListView.cellDidTapped.sink { [weak self] index in
             guard let self = self else { return }
             let courseDetailVC = CourseDetailVC()
+            let model = self.scrapCourseList[index]
+            courseDetailVC.setCourseId(courseId: model.courseId, publicCourseId: model.publicCourseId)
             courseDetailVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(courseDetailVC, animated: true)
         }.store(in: cancelBag)

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/Views/CourseListView/ScrapCourseListView.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/Views/CourseListView/ScrapCourseListView.swift
@@ -15,6 +15,8 @@ final class ScrapCourseListView: UIView {
     var scrapButtonTapped = PassthroughSubject<Void, Never>()
     var cellDidTapped = PassthroughSubject<Int, Never>()
     
+    private var courseList = [ScrapCourse]()
+    
     final let collectionViewInset = UIEdgeInsets(top: 28, left: 16, bottom: 28, right: 16)
     final let itemSpacing: CGFloat = 10
     final let lineSpacing: CGFloat = 20
@@ -53,6 +55,12 @@ final class ScrapCourseListView: UIView {
 // MARK: - Methods
 
 extension ScrapCourseListView {
+    func setData(courseList: [ScrapCourse]) {
+        self.courseList = courseList
+        self.courseListCollectionView.reloadData()
+        self.emptyView.isHidden = !courseList.isEmpty
+    }
+    
     private func setDelegate() {
         courseListCollectionView.delegate = self
         courseListCollectionView.dataSource = self
@@ -94,7 +102,7 @@ extension ScrapCourseListView {
 
 extension ScrapCourseListView: UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 15
+        return courseList.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -102,6 +110,12 @@ extension ScrapCourseListView: UICollectionViewDelegate, UICollectionViewDataSou
                                                             for: indexPath)
                 as? CourseListCVC else { return UICollectionViewCell() }
         cell.setCellType(type: .all)
+        
+        let model = courseList[indexPath.item]
+        
+        let location = "\(model.departure.region) \(model.departure.city)"
+        
+        cell.setData(imageURL: model.image, title: model.title, location: location, didLike: true)
         return cell
     }
 }


### PR DESCRIPTION
## 🌱 작업한 내용

- 보관함 스크랩한 코스 API 연결

## 🌱 PR Point

- 보관함의 스크랩한 코스의 cell을 선택하면 스크랩한 코스 디테일을 보는 뷰(CourseDetailVC)로 넘어가도록 했습니다. 이때, 선택된 코스의 id(courseId)와 publicCourseId를 같이 넘겨주도록 했습니다! CourseDetailVC에서 데이터를 불러오기 위해 서버 통신을 할 때 request로 필요해서 넘겨준거라고 생각하시면 됩니다! 스크랩 코스 상세페이지 API 연결하는 분은 이 Id를 사용해서 서버 통신을 하시면 됩니다..!!!

## 📸 스크린샷
- 생략

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #85 
