### PR TITLE
[Feat] #90 - 마이페이지 닉네임 변경 API 연결

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Network/Router/MyPageRouter/MyPageRouter.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Router/MyPageRouter/MyPageRouter.swift
@@ -14,6 +14,7 @@ enum MyPageRouter {
     case getUploadedCourseInfo
     case getActivityRecordInfo
     case getGoalRewardInfo
+    case updateUserNickname(nickname: String)
 }
 
 extension MyPageRouter: TargetType {
@@ -27,7 +28,7 @@ extension MyPageRouter: TargetType {
     
     var path: String {
         switch self {
-        case .getMyPageInfo:
+        case .getMyPageInfo, .updateUserNickname:
             return "/user"
         case .getUploadedCourseInfo:
             return "/public-course/user"
@@ -42,6 +43,8 @@ extension MyPageRouter: TargetType {
         switch self {
         case .getMyPageInfo, .getUploadedCourseInfo, .getActivityRecordInfo, .getGoalRewardInfo:
             return .get
+        case .updateUserNickname:
+            return .patch
         }
     }
     
@@ -49,12 +52,14 @@ extension MyPageRouter: TargetType {
         switch self {
         case .getMyPageInfo, .getUploadedCourseInfo, .getActivityRecordInfo, .getGoalRewardInfo:
             return .requestPlain
+        case .updateUserNickname(let nickname):
+            return .requestParameters(parameters: ["nickname": nickname], encoding: JSONEncoding.default)
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .getMyPageInfo, .getUploadedCourseInfo, .getActivityRecordInfo, .getGoalRewardInfo:
+        case .getMyPageInfo, .getUploadedCourseInfo, .getActivityRecordInfo, .getGoalRewardInfo, .updateUserNickname:
             return ["Content-Type": "application/json",
                     "machineId": "1"]
         }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/MyPageVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/MyPageVC.swift
@@ -150,6 +150,7 @@ extension MyPageVC {
     
     private func pushToNicknameEditorVC() {
         let nicknameEditorVC = NicknameEditorVC()
+        nicknameEditorVC.delegate = self
         nicknameEditorVC.modalPresentationStyle = .overFullScreen
         self.present(nicknameEditorVC, animated: false)
     }
@@ -328,6 +329,12 @@ extension MyPageVC {
             make.height.equalTo(60)
         }
     }    
+}
+
+extension MyPageVC: NicknameEditorVCDelegate {
+    func nicknameEditDidSuccess() {
+        getMyPageInfo()
+    }
 }
 
 // MARK: - Network


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 마이페이지 닉네임 변경 API 연결

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 닉네임 수정을 완료한 뒤에 viewWillAppear이 호출되지 않아 delegate 패턴을 썼고 나중에 더 공부해보겠습니다..

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 코스 상세 페이지 | <img src = "https://user-images.githubusercontent.com/79050615/211993572-b6dc29d5-b45d-4598-bd09-fc23494c9bbc.mp4" width = 300>  |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #90 
