### PR TITLE
[Feat] #136 - 마이페이지 러닝 기록 상세뷰 UI와 삭제 api 연결

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Global/Supports/SceneDelegate.swift
+++ b/Runnect-iOS/Runnect-iOS/Global/Supports/SceneDelegate.swift
@@ -16,8 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        //let nav = UINavigationController(rootViewController: SplashVC())
-        window.rootViewController = ActivityRecordDetailVC()
+        let nav = UINavigationController(rootViewController: SplashVC())
+        window.rootViewController = nav
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/Runnect-iOS/Runnect-iOS/Global/Supports/SceneDelegate.swift
+++ b/Runnect-iOS/Runnect-iOS/Global/Supports/SceneDelegate.swift
@@ -16,8 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        let nav = UINavigationController(rootViewController: SplashVC())
-        window.rootViewController = nav
+        //let nav = UINavigationController(rootViewController: SplashVC())
+        window.rootViewController = ActivityRecordDetailVC()
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/Runnect-iOS/Runnect-iOS/Global/UIComponents/RNAlertVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Global/UIComponents/RNAlertVC.swift
@@ -16,6 +16,8 @@ final class RNAlertVC: UIViewController {
     
     var rightButtonTapAction: (() -> Void)?
     
+    var deleteRecordDelegate: deleteRecordDelegate?
+        
     // MARK: - UI Components
     
     private let containerView = UIView().then {
@@ -30,7 +32,7 @@ final class RNAlertVC: UIViewController {
     }
     
     private lazy var yesButton = UIButton(type: .custom).then {
-        $0.setTitle("네", for: .normal)
+        $0.setTitle("예", for: .normal)
         $0.titleLabel?.font = .h5
         $0.setTitleColor(.w1, for: .normal)
         $0.layer.backgroundColor = UIColor.m1.cgColor
@@ -78,6 +80,13 @@ extension RNAlertVC {
         self.noButton.addTarget(self, action: #selector(touchUpNoButton), for: .touchUpInside)
         self.yesButton.addTarget(self, action: #selector(touchYesButton), for: .touchUpInside)
     }
+    
+    @discardableResult
+    func setButtonTitle(_ leftButtonTitle: String, _ rightButtonTitle: String) -> Self {
+        self.yesButton.setTitle(rightButtonTitle, for: .normal)
+        self.noButton.setTitle(leftButtonTitle, for: .normal)
+        return self
+    }
 }
 
 // MARK: - @objc Function
@@ -89,6 +98,7 @@ extension RNAlertVC {
     
     @objc private func touchYesButton() {
         self.rightButtonTapAction?()
+        deleteRecordDelegate?.wantsToDelete()
     }
 }
 

--- a/Runnect-iOS/Runnect-iOS/Network/Router/RecordRouter.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Router/RecordRouter.swift
@@ -12,6 +12,7 @@ import Moya
 enum RecordRouter {
     case recordRunning(param: RunningRecordRequestDto)
     case getActivityRecordInfo
+    case deleteRecord(recordIdList: [Int])
 }
 
 extension RecordRouter: TargetType {
@@ -25,7 +26,7 @@ extension RecordRouter: TargetType {
     
     var path: String {
         switch self {
-        case .recordRunning:
+        case .recordRunning, .deleteRecord:
             return "/record"
         case .getActivityRecordInfo:
             return "/record/user"
@@ -38,6 +39,8 @@ extension RecordRouter: TargetType {
             return .post
         case .getActivityRecordInfo:
             return .get
+        case .deleteRecord:
+            return .put
         }
     }
     
@@ -51,12 +54,14 @@ extension RecordRouter: TargetType {
             }
         case .getActivityRecordInfo:
             return .requestPlain
+        case .deleteRecord(let recordIdList):
+            return .requestParameters(parameters: ["recordIdList": recordIdList], encoding: JSONEncoding.default)
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .recordRunning, .getActivityRecordInfo:
+        case .recordRunning, .getActivityRecordInfo, .deleteRecord:
             return Config.defaultHeader
         }
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
@@ -104,6 +104,7 @@ final class CourseDetailVC: UIViewController {
         $0.isScrollEnabled = false
         $0.sizeToFit()
     }
+    
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -9,19 +9,16 @@ import UIKit
 
 import SnapKit
 import Then
+import Moya
 
 final class ActivityRecordDetailVC: UIViewController {
 
     // MARK: - Properties
 
     private let recordProvider = Providers.recordProvider
-    
-    private var activityRecordList = [ActivityRecord]()
-    
+        
     private var courseId: Int?
-    
-    private var publicCourseId: Int?
-    
+        
     // MARK: - UI Components
     
     private lazy var navibar = CustomNavigationBar(self, type: .titleWithLeftButton)
@@ -111,9 +108,18 @@ final class ActivityRecordDetailVC: UIViewController {
 // MARK: - Methods
 
 extension ActivityRecordDetailVC {
-    func setCourseId(courseId: Int?, publicCourseId: Int?) {
+    func setCourseId(courseId: Int?) {
         self.courseId = courseId
-        self.publicCourseId = publicCourseId
+    }
+    
+    func setData(model: ActivityRecord) {
+        self.mapImageView.setImage(with: model.image)
+        self.courseTitleLabel.text = model.title
+        self.recordDistanceValueLabel.text = "\(model.distance) km"
+        self.recordRunningTimeValueLabel.text = model.time
+        self.recordAveragePaceValueLabel.text = model.pace
+        self.recordDateInfoView.setDescriptionText(description: model.createdAt)
+        self.recordDepartureInfoView.setDescriptionText(description: model.departure.region + " " + model.departure.city)
     }
     
     func setDetailInfoStakcView(title: UIView, value: UIView) -> UIStackView {
@@ -162,7 +168,7 @@ extension ActivityRecordDetailVC {
         }
         
         moreButton.snp.makeConstraints { make in
-            make.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(16)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide)
             make.centerY.equalTo(navibar)
         }
     }
@@ -259,7 +265,7 @@ extension ActivityRecordDetailVC {
                     do {
                         let responseDto = try result.map(BaseResponse<ActivityRecordInfoDto>.self)
                         guard let data = responseDto.data else { return }
-                        //self.setData(activityRecordList: data.records)
+                        //self.courseModel = data.course
                     } catch {
                         print(error.localizedDescription)
                     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -320,6 +320,8 @@ extension ActivityRecordDetailVC {
                 let status = result.statusCode
                 if 200..<300 ~= status {
                     print("삭제 성공")
+                    self.navigationController?.popViewController(animated: false)
+                    
                 }
                 if status >= 400 {
                     print("400 error")

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -173,7 +173,7 @@ extension ActivityRecordDetailVC {
         middleScorollView.snp.makeConstraints { make in
             make.top.equalTo(navibar.snp.bottom)
             make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            make.bottom.equalToSuperview()
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
         
         middleScorollView.addSubviews(mapImageView, courseTitleLabel, firstHorizontalDivideLine, recordInfoStackView, secondHorizontalDivideLine)
@@ -197,7 +197,7 @@ extension ActivityRecordDetailVC {
         
         recordInfoStackView.snp.makeConstraints { make in
             make.top.equalTo(firstHorizontalDivideLine.snp.bottom).offset(20)
-            make.leading.trailing.equalToSuperview().inset(16)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(16)
         }
         
         firstVerticalDivideLine.snp.makeConstraints { make in
@@ -239,6 +239,7 @@ extension ActivityRecordDetailVC {
         recordSubInfoStackView.snp.makeConstraints { make in
             make.top.equalTo(secondHorizontalDivideLine.snp.bottom).offset(23)
             make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().inset(30)
         }
     }
 }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -41,9 +41,9 @@ final class ActivityRecordDetailVC: UIViewController {
         $0.font = .h4
     }
     
-    private let recordDateInfoView = CourseDetailInfoView(title: "날짜", description: "0000.00.00")
+    private let recordDateInfoView = CourseDetailInfoView(title: "날짜", description: String())
     
-    private let recordDepartureInfoView = CourseDetailInfoView(title: "출발지", description: "서울시 영등포구")
+    private let recordDepartureInfoView = CourseDetailInfoView(title: "출발지", description: String())
     
     private lazy var recordInfoStackView = UIStackView(arrangedSubviews: [recordDateInfoView, recordDepartureInfoView]).then {
         $0.axis = .vertical
@@ -115,19 +115,50 @@ extension ActivityRecordDetailVC {
     func setData(model: ActivityRecord) {
         self.mapImageView.setImage(with: model.image)
         self.courseTitleLabel.text = model.title
-        self.recordDistanceValueLabel.text = "\(model.distance) km"
-        self.recordRunningTimeValueLabel.text = model.time
-        self.recordAveragePaceValueLabel.text = model.pace
-        self.recordDateInfoView.setDescriptionText(description: model.createdAt)
-        self.recordDepartureInfoView.setDescriptionText(description: model.departure.region + " " + model.departure.city)
+        
+        let location = "\(model.departure.region) \(model.departure.city)"
+        self.recordDepartureInfoView.setDescriptionText(description: location)
+        
+        // 날짜 바꾸기
+        let recordDate = model.createdAt.prefix(10)
+        let resultDate = RNTimeFormatter.changeDateSplit(date: String(recordDate))
+        self.recordDateInfoView.setDescriptionText(description: resultDate)
+        
+        // 이동 시간 바꾸기
+        let recordRunningTime = model.time.suffix(7)
+        self.recordRunningTimeValueLabel.text = String(recordRunningTime)
+        
+        // 평균 페이스 바꾸기
+        let array = spiltRecordAveragePace(model: model)
+        setUpRecordAveragePaceValueLabel(array: array, label: recordAveragePaceValueLabel)
+        setUpRecordDistanceValueLabel(model: model, label: recordDistanceValueLabel)
     }
     
     func setDetailInfoStakcView(title: UIView, value: UIView) -> UIStackView {
         let stackView = UIStackView(arrangedSubviews: [title, value])
         stackView.axis = .vertical
         stackView.alignment = .center
-        stackView.spacing = 2
+        stackView.spacing = 8
         return stackView
+    }
+    
+    private func spiltRecordAveragePace(model: ActivityRecord) -> [String] {
+        let recordAveragePace = model.pace
+        let array = recordAveragePace.split(separator: ":").map { String($0) }
+        return array
+    }
+    
+    private func setUpRecordAveragePaceValueLabel(array: [String], label: UILabel) {
+        let numberArray = array.compactMap { Int($0) }   // 페이스에서 첫번째 인덱스 두번째 값만 가져오기 위해
+        let attributedString = NSMutableAttributedString(string: String(numberArray[1]) + "’", attributes: [.font: UIFont.h3, .foregroundColor: UIColor.g1])
+        attributedString.append(NSAttributedString(string: String(array[2]) + "”", attributes: [.font: UIFont.h3, .foregroundColor: UIColor.g1]))
+        label.attributedText = attributedString
+    }
+    
+    private func setUpRecordDistanceValueLabel(model: ActivityRecord, label: UILabel) {
+        let attributedString = NSMutableAttributedString(string: String(model.distance) + " ", attributes: [.font: UIFont.h3, .foregroundColor: UIColor.g1])
+        attributedString.append(NSAttributedString(string: "km", attributes: [.font: UIFont.b4, .foregroundColor: UIColor.g2]))
+        label.attributedText = attributedString
     }
     
     func setBlackTitle() -> UILabel {
@@ -246,38 +277,6 @@ extension ActivityRecordDetailVC {
             make.top.equalTo(secondHorizontalDivideLine.snp.bottom).offset(23)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().inset(30)
-        }
-    }
-}
-
-// MARK: - Network
-
-extension ActivityRecordDetailVC {
-    func getActivityRecordDetailWithPath() {
-        LoadingIndicator.showLoading()
-        recordProvider.request(.getActivityRecordInfo) { [weak self] response in
-            LoadingIndicator.hideLoading()
-            guard let self = self else { return }
-            switch response {
-            case .success(let result):
-                let status = result.statusCode
-                if 200..<300 ~= status {
-                    do {
-                        let responseDto = try result.map(BaseResponse<ActivityRecordInfoDto>.self)
-                        guard let data = responseDto.data else { return }
-                        //self.courseModel = data.course
-                    } catch {
-                        print(error.localizedDescription)
-                    }
-                }
-                if status >= 400 {
-                    print("400 error")
-                    self.showNetworkFailureToast()
-                }
-            case .failure(let error):
-                print(error.localizedDescription)
-                self.showNetworkFailureToast()
-            }
         }
     }
 }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoTableView/ActivityRecordInfoTVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoTableView/ActivityRecordInfoTVC.swift
@@ -135,7 +135,8 @@ extension ActivityRecordInfoTVC {
     }
     
     private func setUpActivityRecordAveragePaceValueLabel(array: [String], label: UILabel) {
-        let attributedString = NSMutableAttributedString(string: String(array[1]) + "’", attributes: [.font: UIFont.h5, .foregroundColor: UIColor.g1])
+        let numberArray = array.compactMap { Int($0) }   /// 페이스에서 첫번째 인덱스 두번째 값만 가져오기 위해
+        let attributedString = NSMutableAttributedString(string: String(numberArray[1]) + "’", attributes: [.font: UIFont.h5, .foregroundColor: UIColor.g1])
         attributedString.append(NSAttributedString(string: String(array[2]) + "”", attributes: [.font: UIFont.h5, .foregroundColor: UIColor.g1]))
         label.attributedText = attributedString
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
@@ -11,7 +11,11 @@ import SnapKit
 import Then
 import Moya
 
-final class ActivityRecordInfoVC: UIViewController {
+protocol deleteRecordDelegate: AnyObject {
+    func wantsToDelete()
+}
+
+final class ActivityRecordInfoVC: UIViewController, deleteRecordDelegate {
     
     // MARK: - Properties
     
@@ -19,6 +23,10 @@ final class ActivityRecordInfoVC: UIViewController {
     
     private var activityRecordList = [ActivityRecord]()
     
+    private var deleteRecordList = [Int]()
+        
+    weak var delegate: deleteRecordDelegate?
+                
     private var isEditMode: Bool = false
                 
     // MARK: - UI Components
@@ -69,6 +77,11 @@ final class ActivityRecordInfoVC: UIViewController {
         getActivityRecordInfo()
         self.hideTabBar(wantsToHide: true)
     }
+    
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        self.reloadActivityRecordInfoVC()
+//    }
 }
 
 // MARK: - Methods
@@ -93,6 +106,38 @@ extension ActivityRecordInfoVC {
     
     private func setAddTarget() {
         self.editButton.addTarget(self, action: #selector(editButtonDidTap), for: .touchUpInside)
+        self.deleteRecordButton.addTarget(self, action: #selector(deleteRecordButtonDidTap), for: .touchUpInside)
+    }
+    
+    func reloadActivityRecordInfoVC() {
+        self.activityRecordTableView.reloadData()
+        self.editButton.setTitle("편집", for: .normal)
+        self.deleteRecordButton.isHidden = true
+        self.totalNumOfRecordlabel.text = "총 기록 \(self.activityRecordList.count)개"
+        if let selectedRows = activityRecordTableView.indexPathsForSelectedRows {
+            for indexPath in selectedRows {
+                activityRecordTableView.deselectRow(at: indexPath, animated: true)
+            }
+        }
+        self.deleteRecordButton.isEnabled = false
+        self.deleteRecordButton.setTitle(title: "삭제하기")
+        self.activityRecordTableView.reloadData()
+    }
+}
+
+// MARK: - deleteRecordDelegate
+
+extension ActivityRecordInfoVC {
+    func wantsToDelete() {
+        print("삭제 실행")
+        
+        guard let selectedRecords = activityRecordTableView.indexPathsForSelectedRows else { return }
+        
+        for indexPath in selectedRecords {
+            self.deleteRecordList.append(activityRecordList[indexPath.row].id)
+        }
+        
+        deleteRecord()
     }
 }
 
@@ -119,6 +164,16 @@ extension ActivityRecordInfoVC {
             self.deleteRecordButton.isHidden = false
             self.activityRecordTableView.reloadData()
             isEditMode = true
+        }
+    }
+    
+    @objc func deleteRecordButtonDidTap() {
+        let deleteVC = RNAlertVC(description: "러닝 기록을 정말로 삭제하시겠어요?").setButtonTitle("취소", "삭제하기")
+        deleteVC.modalPresentationStyle = .overFullScreen
+        deleteVC.deleteRecordDelegate = self
+        self.present(deleteVC, animated: false, completion: nil)
+        deleteVC.rightButtonTapAction = { [weak self] in
+            deleteVC.dismiss(animated: false)
         }
     }
 }
@@ -195,11 +250,7 @@ extension ActivityRecordInfoVC: UITableViewDelegate {
         guard tableView.cellForRow(at: indexPath) is ActivityRecordInfoTVC else { return }
         guard let selectedRecords = tableView.indexPathsForSelectedRows else { return }
         let activityRecordDetailVC = ActivityRecordDetailVC()
-
-        // 선택한 코스의 정보 저장하기
-        
-        print(activityRecordList[indexPath.row])
-        
+            
         if isEditMode {
             self.deleteRecordButton.isEnabled = true
             let countSelectedRows = selectedRecords.count
@@ -208,6 +259,7 @@ extension ActivityRecordInfoVC: UITableViewDelegate {
             tableView.deselectRow(at: indexPath, animated: true)
             self.deleteRecordButton.setTitle(title: "삭제하기")
             activityRecordDetailVC.setData(model: activityRecordList[indexPath.row])
+            activityRecordDetailVC.setRecordId(recordId: activityRecordList[indexPath.row].courseId)
             
             // 편집 모드가 아닐 때 상세 페이지로 이동
             self.navigationController?.pushViewController(activityRecordDetailVC, animated: true)
@@ -227,7 +279,8 @@ extension ActivityRecordInfoVC: UITableViewDelegate {
         } else {
             tableView.deselectRow(at: indexPath, animated: true)
             self.deleteRecordButton.setTitle(title: "삭제하기")
-        }    }
+        }
+    }
 }
 
 // MARK: - UITableViewDataSource
@@ -285,9 +338,35 @@ extension ActivityRecordInfoVC {
                         let responseDto = try result.map(BaseResponse<ActivityRecordInfoDto>.self)
                         guard let data = responseDto.data else { return }
                         self.setData(activityRecordList: data.records)
+                        
                     } catch {
                         print(error.localizedDescription)
                     }
+                }
+                if status >= 400 {
+                    print("400 error")
+                    self.showNetworkFailureToast()
+                }
+            case .failure(let error):
+                print(error.localizedDescription)
+                self.showNetworkFailureToast()
+            }
+        }
+    }
+    
+    func deleteRecord() {
+        let deleteRecordList = self.deleteRecordList
+        LoadingIndicator.showLoading()
+        recordProvider.request(.deleteRecord(recordIdList: deleteRecordList)) { [weak self] response in
+            LoadingIndicator.hideLoading()
+            guard let self = self else { return }
+            switch response {
+            case .success(let result):
+                print("result:", result)
+                let status = result.statusCode
+                if 200..<300 ~= status {
+                    print("삭제 성공")
+                    self.reloadActivityRecordInfoVC()
                 }
                 if status >= 400 {
                     print("400 error")

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
@@ -259,7 +259,7 @@ extension ActivityRecordInfoVC: UITableViewDelegate {
             tableView.deselectRow(at: indexPath, animated: true)
             self.deleteRecordButton.setTitle(title: "삭제하기")
             activityRecordDetailVC.setData(model: activityRecordList[indexPath.row])
-            activityRecordDetailVC.setRecordId(recordId: activityRecordList[indexPath.row].courseId)
+            activityRecordDetailVC.setRecordId(recordId: activityRecordList[indexPath.row].id)
             
             // 편집 모드가 아닐 때 상세 페이지로 이동
             self.navigationController?.pushViewController(activityRecordDetailVC, animated: true)

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
@@ -20,7 +20,7 @@ final class ActivityRecordInfoVC: UIViewController {
     private var activityRecordList = [ActivityRecord]()
     
     private var isEditMode: Bool = false
-            
+                
     // MARK: - UI Components
     
     private lazy var navibar = CustomNavigationBar(self, type: .titleWithLeftButton).setTitle("러닝 기록")
@@ -194,8 +194,11 @@ extension ActivityRecordInfoVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard tableView.cellForRow(at: indexPath) is ActivityRecordInfoTVC else { return }
         guard let selectedRecords = tableView.indexPathsForSelectedRows else { return }
-        let activityRecordList = activityRecordList[indexPath.item]
-        //ActivityRecordDetailVC.setCourseId(courseId: <#T##Int?#>, publicCourseId: <#T##Int?#>)
+        let activityRecordDetailVC = ActivityRecordDetailVC()
+
+        // 선택한 코스의 정보 저장하기
+        
+        print(activityRecordList[indexPath.row])
         
         if isEditMode {
             self.deleteRecordButton.isEnabled = true
@@ -204,8 +207,10 @@ extension ActivityRecordInfoVC: UITableViewDelegate {
         } else {
             tableView.deselectRow(at: indexPath, animated: true)
             self.deleteRecordButton.setTitle(title: "삭제하기")
-            // 편집 모드가 아닐 때 상세 페이지로 이동
+            activityRecordDetailVC.setData(model: activityRecordList[indexPath.row])
             
+            // 편집 모드가 아닐 때 상세 페이지로 이동
+            self.navigationController?.pushViewController(activityRecordDetailVC, animated: true)
         }
     }
     

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
@@ -105,7 +105,8 @@ extension UploadedCourseInfoVC {
 // MARK: - UICollectionViewDelegateFlowLayout
 
 extension UploadedCourseInfoVC: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout:
+                        UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let screenWidth = UIScreen.main.bounds.width
         let doubleCellWidth = screenWidth - uploadedCourseInset.left - uploadedCourseInset.right - uploadedCourseItemSpacing
         let cellHeight = (doubleCellWidth / 2) * 0.7 + 36
@@ -121,12 +122,11 @@ extension UploadedCourseInfoVC: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
-            let courseDetailVC = CourseDetailVC()
-            let courseModel = uploadedCourseList[indexPath.item]
-            courseDetailVC.setCourseId(courseId: courseModel.courseId, publicCourseId: courseModel.id)
-            courseDetailVC.hidesBottomBarWhenPushed = true
-            self.navigationController?.pushViewController(courseDetailVC, animated: true)
+        let courseDetailVC = CourseDetailVC()
+        let courseModel = uploadedCourseList[indexPath.item]
+        courseDetailVC.setCourseId(courseId: courseModel.courseId, publicCourseId: courseModel.id)
+        courseDetailVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(courseDetailVC, animated: true)
     }
 }
 

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
@@ -105,8 +105,7 @@ extension UploadedCourseInfoVC {
 // MARK: - UICollectionViewDelegateFlowLayout
 
 extension UploadedCourseInfoVC: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout:
-                        UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let screenWidth = UIScreen.main.bounds.width
         let doubleCellWidth = screenWidth - uploadedCourseInset.left - uploadedCourseInset.right - uploadedCourseItemSpacing
         let cellHeight = (doubleCellWidth / 2) * 0.7 + 36


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 마이페이지 러닝 기록 상세뷰 UI 구현
- 러닝기록 삭제 api 연결

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 러닝 기록에서 중복 선택 삭제, 상세 뷰에서 삭제까지 구현했습니다.
- alertvc에서 삭제 버튼 눌렸을 때, delegate를 통해 VC가 알 수 있도록 해보았습니다.
- (왜 안되죠..?) 삭제 이후 테이블뷰가 reload 되지 않는 이유를 모르겠습니다.. 
- 중복 코드가 많아서 지저분한 것 같습니다.. 이후에 수정하겠습니답
- 문제 발견.. 만약에 러닝 기록이 없음 -> 코스 그리기 페이지로 이동 -> hideToTabBar한 상태라 탭바가 업숨 => 어쩌죠잉

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 러닝기록 | <img src = "https://github.com/Runnect/Runnect-iOS/assets/79050615/98245294-4aa7-4df8-b883-a4e3ac0f76a6" width = 300> |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #136 
