### PR TITLE
[Feat] #139 - 러닝 기록 수정 페이지 UI 및 api 연결

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Network/Router/RecordRouter.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Router/RecordRouter.swift
@@ -13,6 +13,7 @@ enum RecordRouter {
     case recordRunning(param: RunningRecordRequestDto)
     case getActivityRecordInfo
     case deleteRecord(recordIdList: [Int])
+    case updateRecordTitle(recordId: Int, recordTitle: String)
 }
 
 extension RecordRouter: TargetType {
@@ -30,6 +31,8 @@ extension RecordRouter: TargetType {
             return "/record"
         case .getActivityRecordInfo:
             return "/record/user"
+        case .updateRecordTitle(recordId: let recordId, _):
+            return "/record/\(recordId)"
         }
     }
     
@@ -41,6 +44,8 @@ extension RecordRouter: TargetType {
             return .get
         case .deleteRecord:
             return .put
+        case .updateRecordTitle:
+            return .patch
         }
     }
     
@@ -56,12 +61,17 @@ extension RecordRouter: TargetType {
             return .requestPlain
         case .deleteRecord(let recordIdList):
             return .requestParameters(parameters: ["recordIdList": recordIdList], encoding: JSONEncoding.default)
+        case .updateRecordTitle(_, let recordTitle):
+            do {
+                return .requestParameters(parameters: ["title": recordTitle], encoding: JSONEncoding.default)
+            } catch {
+                fatalError("Encoding 실패")}
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .recordRunning, .getActivityRecordInfo, .deleteRecord:
+        default:
             return Config.defaultHeader
         }
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDrawing/VC/CourseDrawingHomeVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDrawing/VC/CourseDrawingHomeVC.swift
@@ -33,6 +33,10 @@ final class CourseDrawingHomeVC: UIViewController {
         self.setLayout()
         self.setAddTarget()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.hideTabBar(wantsToHide: false)
+    }
 }
 
 // MARK: - Methods

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -180,6 +180,10 @@ extension ActivityRecordDetailVC {
         middleScorollView.contentInset = contentInset
         middleScorollView.scrollIndicatorInsets = contentInset
     }
+    
+    @objc private func finishEditButtonDidTap() {
+        editRecordTitle()
+    }
 }
 
 // MARK: - Methods
@@ -211,6 +215,7 @@ extension ActivityRecordDetailVC {
     private func setAddTarget() {
         self.moreButton.addTarget(self, action: #selector(moreButtonDidTap), for: .touchUpInside)
         self.courseTitleTextField.addTarget(self, action: #selector(textFieldTextDidChange), for: .editingChanged)
+        self.finishEditButton.addTarget(self, action: #selector(finishEditButtonDidTap), for: .touchUpInside)
     }
     
     func setDetailInfoStakcView(title: UIView, value: UIView) -> UIStackView {
@@ -455,6 +460,31 @@ extension ActivityRecordDetailVC {
                     let activityRecordInfoVC = ActivityRecordInfoVC()
                     activityRecordInfoVC.getActivityRecordInfo()
                     activityRecordInfoVC.reloadActivityRecordInfoVC()
+                }
+                if status >= 400 {
+                    print("400 error")
+                    self.showNetworkFailureToast()
+                }
+            case .failure(let error):
+                print(error.localizedDescription)
+                self.showNetworkFailureToast()
+            }
+        }
+    }
+    
+    private func editRecordTitle() {
+        guard let recordId = self.recordId else { return }
+        guard let editRecordTitle = self.courseTitleTextField.text else { return }
+        LoadingIndicator.showLoading()
+        recordProvider.request(.updateRecordTitle(recordId: recordId, recordTitle: editRecordTitle)) { [weak self] response in
+            LoadingIndicator.hideLoading()
+            guard let self = self else { return }
+            switch response {
+            case .success(let result):
+                print("result:", result)
+                let status = result.statusCode
+                if 200..<300 ~= status {
+                    print("제목 수정 성공")
                 }
                 if status >= 400 {
                     print("400 error")

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -46,7 +46,7 @@ final class ActivityRecordDetailVC: UIViewController {
     
     private let courseTitleTextField = UITextField().then {
         $0.attributedPlaceholder = NSAttributedString(
-            string: String(),
+            string: "글 제목",
             attributes: [.font: UIFont.h4, .foregroundColor: UIColor.g3]
         )
         $0.font = .h4
@@ -103,6 +103,7 @@ final class ActivityRecordDetailVC: UIViewController {
     
     private lazy var finishEditButton = CustomButton(title: "완료").then {
         $0.isHidden = true
+        $0.isEnabled = false
     }
     
     // MARK: - View Life Cycle
@@ -147,6 +148,10 @@ extension ActivityRecordDetailVC {
         guard let text = courseTitleTextField.text else { return }
         
         self.finishEditButton.isEnabled = !text.isEmpty
+        
+        if text == self.courseTitleLabel.text {
+            self.finishEditButton.isEnabled = false
+        }
         
         if text.count > courseTitleMaxLength {
             let index = text.index(text.startIndex, offsetBy: courseTitleMaxLength)
@@ -418,7 +423,7 @@ extension ActivityRecordDetailVC {
             make.top.equalTo(secondHorizontalDivideLine.snp.bottom).offset(22)
             make.centerX.equalToSuperview()
         }
-        
+                
         middleScorollView.addSubview(finishEditButton)
 
         finishEditButton.snp.makeConstraints { make in
@@ -461,6 +466,4 @@ extension ActivityRecordDetailVC {
             }
         }
     }
-    
-    
 }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -26,7 +26,7 @@ final class ActivityRecordDetailVC: UIViewController {
     // MARK: - UI Components
     
     private lazy var navibar = CustomNavigationBar(self, type: .titleWithLeftButton)
-    
+        
     private let moreButton = UIButton(type: .system).then {
         $0.setImage(ImageLiterals.icMore, for: .normal)
         $0.tintColor = .g1
@@ -128,7 +128,7 @@ extension ActivityRecordDetailVC {
         let editAction = UIAlertAction(title: "수정하기", style: .default, handler: {(_: UIAlertAction!) in
             // 수정 모드일 때
             self.isEditMode = true
-            self.setEditModeLayout()
+            self.setEditMode()
         })
         let deleteVC = RNAlertVC(description: "러닝 기록을 정말로 삭제하시겠어요?").setButtonTitle("취소", "삭제하기")
         deleteVC.modalPresentationStyle = .overFullScreen
@@ -386,7 +386,24 @@ extension ActivityRecordDetailVC {
         }
     }
     
-    private func setEditModeLayout() {
+    private func setEditMode() {
+        self.navibar.isHidden = true
+        
+        let editNavibar = CustomNavigationBar(self, type: .editModeForTitleWithLeftButton)
+        
+        view.addSubview(editNavibar)
+        
+        editNavibar.snp.makeConstraints {  make in
+            make.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(48)
+        }
+        
+        middleScorollView.snp.makeConstraints { make in
+            make.top.equalTo(editNavibar.snp.bottom)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+        
         mapImageView.snp.remakeConstraints { make in
             make.top.equalToSuperview()
             make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
@@ -398,7 +415,7 @@ extension ActivityRecordDetailVC {
         self.courseTitleTextField.text = self.courseTitleLabel.text
         
         middleScorollView.addSubview(courseTitleTextField)
-        
+                
         courseTitleTextField.snp.makeConstraints { make in
             make.top.equalTo(mapImageView.snp.bottom).offset(27)
             make.leading.trailing.equalToSuperview().inset(16)
@@ -438,7 +455,6 @@ extension ActivityRecordDetailVC {
             make.height.equalTo(44)
         }
     }
-    
 }
 
 // MARK: - Network

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -18,7 +18,9 @@ final class ActivityRecordDetailVC: UIViewController {
     private let recordProvider = Providers.recordProvider
         
     private var recordId: Int?
-        
+    
+    private var isEditMode: Bool = false
+            
     // MARK: - UI Components
     
     private lazy var navibar = CustomNavigationBar(self, type: .titleWithLeftButton)
@@ -88,6 +90,10 @@ final class ActivityRecordDetailVC: UIViewController {
         $0.distribution = .fill
     }
     
+    private lazy var finishEditButton = CustomButton(title: "완료").then {
+        $0.isHidden = true
+    }
+    
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {
@@ -106,7 +112,9 @@ extension ActivityRecordDetailVC {
     @objc func moreButtonDidTap() {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let editAction = UIAlertAction(title: "수정하기", style: .default, handler: {(_: UIAlertAction!) in
-            //self.navigationController?.pushViewController(courseEditVC, animated: false)
+            // 수정 모드일 때
+            self.isEditMode = true
+            self.setEditModeLayout()
         })
         let deleteVC = RNAlertVC(description: "러닝 기록을 정말로 삭제하시겠어요?").setButtonTitle("취소", "삭제하기")
         deleteVC.modalPresentationStyle = .overFullScreen
@@ -302,6 +310,37 @@ extension ActivityRecordDetailVC {
             make.bottom.equalToSuperview().inset(30)
         }
     }
+    
+    private func setEditModeLayout() {
+        mapImageView.snp.remakeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(middleScorollView.snp.width)
+        }
+        
+        secondHorizontalDivideLine.snp.remakeConstraints { make in
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(7)
+            make.top.equalTo(recordInfoStackView.snp.bottom).offset(11)
+        }
+        
+        self.finishEditButton.isHidden = false
+        
+        recordSubInfoStackView.snp.remakeConstraints { make in
+            make.top.equalTo(secondHorizontalDivideLine.snp.bottom).offset(20)
+            make.centerX.equalToSuperview()
+        }
+        
+        middleScorollView.addSubview(finishEditButton)
+
+        finishEditButton.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(30)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(16)
+            make.top.equalTo(recordSubInfoStackView.snp.bottom).offset(44)
+            make.height.equalTo(44)
+        }
+    }
+    
 }
 
 // MARK: - Network

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -134,11 +134,8 @@ extension ActivityRecordDetailVC {
 // MARK: - Methods
 
 extension ActivityRecordDetailVC {
-    func setRecordId(recordId: Int?) {
-        self.recordId = recordId
-    }
-    
     func setData(model: ActivityRecord) {
+        self.recordId = model.id
         self.mapImageView.setImage(with: model.image)
         self.courseTitleLabel.text = model.title
         
@@ -360,7 +357,9 @@ extension ActivityRecordDetailVC {
                 if 200..<300 ~= status {
                     print("삭제 성공")
                     self.navigationController?.popViewController(animated: false)
-                    
+                    let activityRecordInfoVC = ActivityRecordInfoVC()
+                    activityRecordInfoVC.getActivityRecordInfo()
+                    activityRecordInfoVC.reloadActivityRecordInfoVC()
                 }
                 if status >= 400 {
                     print("400 error")

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
@@ -24,11 +24,11 @@ final class ActivityRecordInfoVC: UIViewController, deleteRecordDelegate {
     private var activityRecordList = [ActivityRecord]()
     
     private var deleteRecordList = [Int]()
-        
+    
     weak var delegate: deleteRecordDelegate?
-                
+    
     private var isEditMode: Bool = false
-                
+    
     // MARK: - UI Components
     
     private lazy var navibar = CustomNavigationBar(self, type: .titleWithLeftButton).setTitle("러닝 기록")
@@ -65,9 +65,9 @@ final class ActivityRecordInfoVC: UIViewController, deleteRecordDelegate {
     }
     
     // MARK: - View Life Cycle
-        
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         setNavigationBar()
         setUI()
         setLayout()
@@ -77,11 +77,6 @@ final class ActivityRecordInfoVC: UIViewController, deleteRecordDelegate {
         getActivityRecordInfo()
         self.hideTabBar(wantsToHide: true)
     }
-    
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        self.reloadActivityRecordInfoVC()
-//    }
 }
 
 // MARK: - Methods
@@ -110,7 +105,6 @@ extension ActivityRecordInfoVC {
     }
     
     func reloadActivityRecordInfoVC() {
-        self.activityRecordTableView.reloadData()
         self.editButton.setTitle("편집", for: .normal)
         self.deleteRecordButton.isHidden = true
         self.totalNumOfRecordlabel.text = "총 기록 \(self.activityRecordList.count)개"
@@ -168,12 +162,12 @@ extension ActivityRecordInfoVC {
     }
     
     @objc func deleteRecordButtonDidTap() {
-        let deleteVC = RNAlertVC(description: "러닝 기록을 정말로 삭제하시겠어요?").setButtonTitle("취소", "삭제하기")
-        deleteVC.modalPresentationStyle = .overFullScreen
-        deleteVC.deleteRecordDelegate = self
-        self.present(deleteVC, animated: false, completion: nil)
-        deleteVC.rightButtonTapAction = { [weak self] in
-            deleteVC.dismiss(animated: false)
+        let deleteAlertVC = RNAlertVC(description: "러닝 기록을 정말로 삭제하시겠어요?").setButtonTitle("취소", "삭제하기")
+        deleteAlertVC.modalPresentationStyle = .overFullScreen
+        deleteAlertVC.deleteRecordDelegate = self
+        self.present(deleteAlertVC, animated: false, completion: nil)
+        deleteAlertVC.rightButtonTapAction = { [weak self] in
+            deleteAlertVC.dismiss(animated: false)
         }
     }
 }
@@ -249,17 +243,16 @@ extension ActivityRecordInfoVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard tableView.cellForRow(at: indexPath) is ActivityRecordInfoTVC else { return }
         guard let selectedRecords = tableView.indexPathsForSelectedRows else { return }
-        let activityRecordDetailVC = ActivityRecordDetailVC()
             
         if isEditMode {
             self.deleteRecordButton.isEnabled = true
             let countSelectedRows = selectedRecords.count
             self.deleteRecordButton.setTitle(title: "삭제하기(\(countSelectedRows))")
         } else {
+            let activityRecordDetailVC = ActivityRecordDetailVC()
             tableView.deselectRow(at: indexPath, animated: true)
             self.deleteRecordButton.setTitle(title: "삭제하기")
             activityRecordDetailVC.setData(model: activityRecordList[indexPath.row])
-            activityRecordDetailVC.setRecordId(recordId: activityRecordList[indexPath.row].id)
             
             // 편집 모드가 아닐 때 상세 페이지로 이동
             self.navigationController?.pushViewController(activityRecordDetailVC, animated: true)
@@ -366,6 +359,7 @@ extension ActivityRecordInfoVC {
                 let status = result.statusCode
                 if 200..<300 ~= status {
                     print("삭제 성공")
+                    self.getActivityRecordInfo()
                     self.reloadActivityRecordInfoVC()
                 }
                 if status >= 400 {


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 러닝 기록 수정 페이지 UI 및 api 연결

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 수정 페이지 UI 구현 및 api를 연결했습니다.
- 수정 페이지에서 네비바의 이전 버튼을 눌렀을 때, AlertVC가 나오게 하기 위하여 커스텀네비바의 코드를 수정했습니다.
- 수정을 완료하여 버튼을 눌렀을 때, 팝업이 뜨지 않아 뭔가 어색?해 기디에 문의해놓았고 답변 이후 반영하겠습니다.

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 러닝 기록 수정 페이지 | <img src = "https://github.com/Runnect/Runnect-iOS/assets/79050615/32a37592-b891-4f5e-bf85-44d44ea02ff0" width = 300> |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #139 
