### PR TITLE
[Fix] #147 - 업로드한 코스 디테일뷰 서버통신 실패 해결

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Network/Dto/CourseDetailDto/ResponseDto/UploadedCourseDetailResponseDto.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Dto/CourseDetailDto/ResponseDto/UploadedCourseDetailResponseDto.swift
@@ -18,7 +18,7 @@ struct UploadedCourseDetailResponseDto: Codable {
 
 struct UploadUser: Codable {
     let nickname: String
-    let level: Int
+    let level: String
     let image: String
     let isNowUser: Bool?
 }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
@@ -289,7 +289,7 @@ extension UploadedCourseInfoVC: UICollectionViewDataSource {
         guard collectionView.cellForItem(at: indexPath) is CourseListCVC else { return }
         guard let selectedCells = collectionView.indexPathsForSelectedItems else { return }
         guard let cell = collectionView.cellForItem(at: indexPath) as? CourseListCVC else { return }
-        let courseList = uploadedCourseList[indexPath.item]
+        let publicCourseModel = uploadedCourseList[indexPath.item]
         if isEditMode {
             self.deleteCourseButton.isEnabled = true
             let countSelectCells = selectedCells.count
@@ -300,6 +300,7 @@ extension UploadedCourseInfoVC: UICollectionViewDataSource {
             self.deleteCourseButton.setTitle(title: "삭제하기")
             self.deleteCourseButton.setEnabled(true)
             let courseDetailVC = CourseDetailVC()
+            courseDetailVC.setCourseId(courseId: publicCourseModel.courseId, publicCourseId: publicCourseModel.id)
             courseDetailVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(courseDetailVC, animated: true)
             cell.selectCell(didSelect: false)


### PR DESCRIPTION
## 🌱 작업한 내용

- 마이페이지에서 업로드한 코스 목록에서 디테일뷰로 넘어갈 때 데이터가 안들어오는 문제 해결
- CourseDetailVC에 courseId와 publicCourseId를 넘겨줬어야 했는데 그게 없었습니다.
- 서버에서 user의 level을 넘겨줄 때 String으로 주고 있는데 우리 dto에는 Int로 되어 있었습니다.

## 🌱 PR Point

생략

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #147
