### PR TITLE
[Fix] #155 - 보관함 편집모드 애니메이션 버그 수정

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/VC/CourseStorageVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/VC/CourseStorageVC.swift
@@ -132,6 +132,8 @@ extension CourseStorageVC {
     
     private func finishEditMode(withDuration: TimeInterval = 0) {
         showTabBarWithAnimation()
+        self.deleteCourseButton.setEnabled(false)
+        self.deleteCourseButton.setTitle(title: "삭제하기")
         
         UIView.animate(withDuration: withDuration) {
             self.deleteCourseButton.transform = CGAffineTransform(translationX: 0, y: 34)
@@ -222,31 +224,19 @@ extension CourseStorageVC: ScrapCourseListViewDelegate {
 extension CourseStorageVC: PrivateCourseListViewDelegate {
     
     func courseListEditButtonTapped() {
-        if privateCourseListView.isEditMode == true {
-            self.deleteCourseButton.setTitle(title: "삭제하기")
-            startEditMode(withDuration: 0.7)
-        }
-        
-        if privateCourseListView.isEditMode == false {
-            finishEditMode(withDuration: 0.7)
-        }
+        privateCourseListView.isEditMode ? startEditMode(withDuration: 0.7) : finishEditMode(withDuration: 0.7)
     }
     
     func selectCellDidTapped() {
         guard let selectedCells = privateCourseListView.courseListCollectionView.indexPathsForSelectedItems else { return }
+        
         let countSelectCells = selectedCells.count
+        
         if privateCourseListView.isEditMode == true {
-            if privateCourseListView.isEditMode == false {
-                self.deleteCourseButton.isEnabled = false
-                self.deleteCourseButton.setTitle(title: "삭제하기")
-            }
             self.deleteCourseButton.setTitle(title: "삭제하기(\(countSelectCells))")
-            self.deleteCourseButton.isEnabled = false
-            self.deleteCourseButton.setEnabled(true)
         }
-        if selectedCells.count == 0 {
-            self.deleteCourseButton.isEnabled = false
-        }
+        
+        self.deleteCourseButton.setEnabled(countSelectCells != 0)
     }
 }
 // MARK: - Network
@@ -334,6 +324,7 @@ extension CourseStorageVC {
         courseProvider.request(.deleteCourse(courseIdList: courseIdList)) { [weak self] response in
             LoadingIndicator.hideLoading()
             guard let self = self else { return }
+            self.privateCourseListView.isEditMode = false
             switch response {
             case .success(let result):
                 print("리절트", result)
@@ -342,7 +333,6 @@ extension CourseStorageVC {
                     print("삭제 성공")
                     self.getPrivateCourseList()
                     self.finishEditMode(withDuration: 0.7)
-                    
                 }
                 if status >= 400 {
                     print("400 error")

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/Views/CourseListView/PrivateCourseListView.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/Views/CourseListView/PrivateCourseListView.swift
@@ -232,6 +232,7 @@ extension PrivateCourseListView: UICollectionViewDelegate, UICollectionViewDataS
         delegate?.selectCellDidTapped()
     }
 }
+
 // MARK: - UICollectionViewDelegateFlowLayout
 
 extension PrivateCourseListView: UICollectionViewDelegateFlowLayout {

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/Views/CourseListView/PrivateCourseListView.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/Views/CourseListView/PrivateCourseListView.swift
@@ -114,19 +114,17 @@ extension PrivateCourseListView {
 
 extension PrivateCourseListView {
     @objc func editButtonDidTap() {
+        isEditMode.toggle()
+        
         if isEditMode {
+            self.totalNumOfRecordlabel.text = "코스 선택"
+            self.editButton.setTitle("취소", for: .normal)
+        } else {
             self.totalNumOfRecordlabel.text = "총 코스 \(self.courseList.count)개"
             self.editButton.setTitle("편집", for: .normal)
-            self.delegate?.courseListEditButtonTapped()
-            self.courseListCollectionView.reloadData()
-            isEditMode = false
-        } else {
-            self.totalNumOfRecordlabel.text = "코스 선택"
-            self.delegate?.courseListEditButtonTapped()
-            self.editButton.setTitle("취소", for: .normal)
-            self.courseListCollectionView.reloadData()
-            isEditMode = true
         }
+        
+        self.delegate?.courseListEditButtonTapped()
     }
 }
 // MARK: - UI & Layout


### PR DESCRIPTION
## 🌱 작업한 내용

- 보관함 편집모드 애니메이션 버그 수정

## 🌱 PR Point

### 문제의 원인
- 편집 모드를 끝내면 보관함VC와 `privateCourseListView` 둘다 편집 모드를 끈 상태로 UI가 바뀌어야 하는데 후자를 처리하지 않아서 생긴 문제였음
- 따라서 이 부분을 처리하고 editMode의 UI 변경 코드들을 한 곳을 모아(isEditMode) 가독성을 높이고 불필요한 코드를 많이 제거함
- 보관함 뷰에서 이탈했을 때 탭바 위치가 의도하지 않은 위치로 바뀌는 버그를 수정함

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 삭제하기 애니메이션 | ![Simulator Screen Recording - iPhone 14 - 2023-05-28 at 23 06 38](https://github.com/Runnect/Runnect-iOS/assets/77267404/a9cb51e6-2363-42c7-af9f-fc5b2e2d5ca8) |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #155 
