### PR TITLE
[Fix] #154 - 1차 릴리즈 QA 2차 반영

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
@@ -113,6 +113,9 @@ final class CourseDetailVC: UIViewController {
         setUI()
         setLayout()
         setAddTarget()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
         getUploadedCourseDetail()
     }
 }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
@@ -32,6 +32,7 @@ final class CourseDetailVC: UIViewController {
     private var isMyCourse: Bool?
     
     // MARK: - UI Components
+    
     private lazy var navibar = CustomNavigationBar(self, type: .titleWithLeftButton)
     private let moreButton = UIButton(type: .system).then {
         $0.setImage(ImageLiterals.icMore, for: .normal)
@@ -147,10 +148,11 @@ extension CourseDetailVC {
         
         if isMyCourse == true {
             let editAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-            let courseEditVC = CourseEditVC()
-            courseEditVC.loadData(model: uploadedCourseDetailModel)
-            courseEditVC.publicCourseId = self.publicCourseId
+            
             let editAction = UIAlertAction(title: "수정하기", style: .default, handler: {(_: UIAlertAction!) in
+                let courseEditVC = CourseEditVC()
+                courseEditVC.loadData(model: uploadedCourseDetailModel)
+                courseEditVC.publicCourseId = self.publicCourseId
                 self.navigationController?.pushViewController(courseEditVC, animated: false)
             })
             let deleteAlertVC = RNAlertVC(description: "러닝 기록을 정말로 삭제하시겠어요?").setButtonTitle("취소", "삭제하기")
@@ -160,7 +162,8 @@ extension CourseDetailVC {
             }
             deleteAlertVC.modalPresentationStyle = .overFullScreen
             let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive, handler: {(_: UIAlertAction!) in
-                self.present(deleteAlertVC, animated: false, completion: nil)})
+                self.present(deleteAlertVC, animated: false, completion: nil)
+            })
             [ editAction, deleteAction, cancelAction].forEach { editAlertController.addAction($0) }
             present(editAlertController, animated: false, completion: nil)
         } else {
@@ -227,7 +230,6 @@ extension CourseDetailVC {
     
     private func setAddTarget() {
         likeButton.addTarget(self, action: #selector(likeButtonDidTap), for: .touchUpInside)
-        
         moreButton.addTarget(self, action: #selector(moreButtonDidTap), for: .touchUpInside)
     }
     
@@ -239,9 +241,10 @@ extension CourseDetailVC {
     }
 }
 
+// MARK: - Layout Helpers
+
 extension CourseDetailVC {
-    
-    // MARK: - Layout Helpers
+
     private func setNavigationBar() {
         view.addSubview(navibar)
         view.addSubview(moreButton)
@@ -359,6 +362,8 @@ extension CourseDetailVC {
         }
     }
 }
+
+// MARK: - Network
 
 extension CourseDetailVC {
     private func getUploadedCourseDetail() {

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
@@ -83,9 +83,9 @@ final class CourseDetailVC: UIViewController {
         $0.font = .h4
     }
     
-    private let courseDistanceInfoView = CourseDetailInfoView(title: "거리", description: "0.0km")
+    private let courseDistanceInfoView = CourseDetailInfoView(title: "거리", description: String())
     
-    private let courseDepartureInfoView = CourseDetailInfoView(title: "출발지", description: "위치")
+    private let courseDepartureInfoView = CourseDetailInfoView(title: "출발지", description: String())
     
     private lazy var courseDetailStackView = UIStackView(arrangedSubviews: [courseDistanceInfoView, courseDepartureInfoView]).then {
         $0.axis = .vertical
@@ -113,9 +113,11 @@ final class CourseDetailVC: UIViewController {
         setUI()
         setLayout()
         setAddTarget()
+        self.hideTabBar(wantsToHide: true)
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        self.hideTabBar(wantsToHide: true)
         getUploadedCourseDetail()
     }
 }
@@ -240,7 +242,7 @@ extension CourseDetailVC {
             make.height.equalTo(48)
         }
         moreButton.snp.makeConstraints { make in
-            make.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(16)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide)
             make.centerY.equalTo(navibar)
         }
         

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
@@ -210,7 +210,8 @@ extension CourseDetailVC {
         self.uploadedCourseDetailModel = model
         self.mapImageView.setImage(with: model.publicCourse.image)
         self.profileImageView.image = GoalRewardInfoModel.stampNameImageDictionary[model.user.image]
-        self.profileNameLabel.text = model.user.nickname
+        // 탈퇴 유저 처리
+        model.user.nickname == "알 수 없음" ? setNullUser() : (self.profileNameLabel.text = model.user.nickname)
         self.runningLevelLabel.text = "Lv. \(model.user.level)"
         self.courseTitleLabel.text = model.publicCourse.title
         self.isMyCourse = model.user.isNowUser
@@ -228,6 +229,13 @@ extension CourseDetailVC {
         likeButton.addTarget(self, action: #selector(likeButtonDidTap), for: .touchUpInside)
         
         moreButton.addTarget(self, action: #selector(moreButtonDidTap), for: .touchUpInside)
+    }
+    
+    private func setNullUser() {
+        self.profileImageView.image = ImageLiterals.imgPerson
+        self.profileNameLabel.textColor = .g2
+        self.profileNameLabel.text = "(알 수 없음)"
+        self.runningLevelLabel.isHidden = true
     }
 }
 

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseEditVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseEditVC.swift
@@ -50,7 +50,7 @@ class CourseEditVC: UIViewController {
     private let departureInfoView = CourseDetailInfoView(title: "출발지", description: "")
     private let placeholder = "코스에 대한 소개를 적어주세요.(난이도/풍경/지형)"
     
-    private lazy var activityTextView = UITextView().then {
+    private let activityTextView = UITextView().then {
         $0.font = .b3
         $0.backgroundColor = .m3
         $0.tintColor = .m1
@@ -65,7 +65,6 @@ class CourseEditVC: UIViewController {
         setNavigationBar()
         setUI()
         setLayout()
-        setupTextView()
         setAddTarget()
         setKeyboardNotification()
         setTapGesture()
@@ -148,7 +147,7 @@ extension CourseEditVC {
             object: nil)
     }
     
-    private func isTextChanged(_ textFieldtext: String, _ textViewtext: String) {
+    private func textDidChanged(_ textFieldtext: String, _ textViewtext: String) {
         // 둘 중 하나라도 비어있으면 버튼 비활성화
         if textFieldtext.isEmpty || textViewtext.isEmpty {
             editButton.isEnabled = false
@@ -311,10 +310,6 @@ extension CourseEditVC {
             make.height.equalTo(187)
         }
     }
-    
-    func setupTextView() {
-        activityTextView.delegate = self
-    }
 }
 
 // MARK: - UITextFieldDelegate
@@ -323,7 +318,7 @@ extension CourseEditVC: UITextFieldDelegate {
     @objc private func textFieldTextDidChange() {
         guard let text = courseTitleTextField.text else { return }
         
-        isTextChanged(text, self.activityTextView.text)
+        textDidChanged(text, self.activityTextView.text)
         
         if text.count > courseTitleMaxLength {
             let index = text.index(text.startIndex, offsetBy: courseTitleMaxLength)
@@ -361,7 +356,7 @@ extension CourseEditVC: UITextViewDelegate {
         textView.textColor = .g1
                 
         guard let courseTitleTextFieldText = self.courseTitleTextField.text else { return }
-        isTextChanged(courseTitleTextFieldText, text)
+        textDidChanged(courseTitleTextFieldText, text)
         
         if text.count > self.activityTextMaxLength {
             self.activityTextView.deleteBackward()

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseEditVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseEditVC.swift
@@ -190,27 +190,24 @@ extension CourseEditVC {
     }
 }
 
-// MARK: - naviVar Layout
+// MARK: - Layout Helpers
 
 extension CourseEditVC {
     private func setNavigationBar() {
         view.addSubview(navibar)
+        
         navibar.snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
             make.height.equalTo(48)
         }
     }
-    // MARK: - setUI
     
     private func setUI() {
         view.backgroundColor = .w1
         scrollView.backgroundColor = .clear
         buttonContainerView.backgroundColor = .w1
         mapImageView.backgroundColor = .systemGray4
-        
     }
-    
-    // MARK: - Layout Helpers
     
     private func setLayout() {
         view.addSubview(buttonContainerView)
@@ -289,6 +286,8 @@ extension CourseEditVC {
     }
 }
 
+// MARK: - UITextViewDelegate
+
 extension CourseEditVC: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -312,6 +311,7 @@ extension CourseEditVC: UITextViewDelegate {
             activityTextView.deleteBackward()
         }
     }
+    
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || textView.text == placeholder {
             activityTextView.textColor = .g3

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDiscovery/Views/VC/MyCourseSelectVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDiscovery/Views/VC/MyCourseSelectVC.swift
@@ -29,10 +29,11 @@ class MyCourseSelectVC: UIViewController {
     // MARK: - UI Components
     
     private lazy var navibar = CustomNavigationBar(self, type: .titleWithLeftButton).setTitle("불러오기")
-    private let selectButton = CustomButton(title: "선택하기").setEnabled(false)
     
-    // MARK: - collectionview
-    
+    private lazy var selectButton = CustomButton(title: "선택하기").setEnabled(false).then {
+        $0.isHidden = true
+    }
+        
     private lazy var mapCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
@@ -45,6 +46,11 @@ class MyCourseSelectVC: UIViewController {
         return collectionView
     }()
     
+    private lazy var emptyView = ListEmptyView(description: "공유할 수 있는 코스가 없어요!\n코스를 그려주세요!",
+                                               buttonTitle: "코스 그리기").then {
+        $0.setImage(ImageLiterals.imgPaper, size: CGSize(width: 189, height: 169))
+    }
+        
     // MARK: - Constants
     
     final let collectionViewInset = UIEdgeInsets(top: 28, left: 16, bottom: 28, right: 16)
@@ -75,11 +81,14 @@ extension MyCourseSelectVC {
     private func setData(courseList: [Course]) {
         self.courseList = courseList
         mapCollectionView.reloadData()
+        self.emptyView.isHidden = !courseList.isEmpty
+        self.selectButton.isHidden = courseList.isEmpty
     }
-    
+
     private func setDelegate() {
         mapCollectionView.delegate = self
         mapCollectionView.dataSource = self
+        emptyView.delegate = self
     }
     
     private func register() {
@@ -117,11 +126,13 @@ extension MyCourseSelectVC {
     private func setUI() {
         view.backgroundColor = .w1
         self.tabBarController?.tabBar.isHidden = true
+        self.emptyView.isHidden = true
     }
         
     private func setLayout() {
         view.addSubviews(selectButton, mapCollectionView)
         self.view.bringSubviewToFront(selectButton)
+        mapCollectionView.addSubview(emptyView)
         
         selectButton.snp.makeConstraints { make in
             make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(16)
@@ -133,6 +144,11 @@ extension MyCourseSelectVC {
             make.top.equalTo(navibar.snp.bottom)
             make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
             make.bottom.equalTo(selectButton.snp.top).inset(-25)
+        }
+        
+        emptyView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalTo(view.safeAreaLayoutGuide)
         }
     }
 }
@@ -234,5 +250,13 @@ extension MyCourseSelectVC {
                 self.showNetworkFailureToast()
             }
         }
+    }
+}
+
+// MARK: - Section Heading
+
+extension MyCourseSelectVC: ListEmptyViewDelegate {
+    func emptyViewButtonTapped() {
+        self.tabBarController?.selectedIndex = 0
     }
 }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/Views/CourseListView/PrivateCourseListView.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseStorage/Views/CourseListView/PrivateCourseListView.swift
@@ -169,7 +169,7 @@ extension PrivateCourseListView {
             make.trailing.equalToSuperview().inset(16)
             make.width.equalTo(47)
             make.height.equalTo(22)
-            make.top.equalToSuperview().offset(5)
+            make.top.equalToSuperview().offset(8)
         }
         
         courseListCollectionView.snp.makeConstraints { make in

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -186,7 +186,7 @@ extension ActivityRecordDetailVC {
     }
     
     @objc private func finishEditButtonDidTap() {
-//        editRecordTitle()
+        editRecordTitle()
         showToast(message: "제목 수정이 완료되었어요")
         
         // 수정이 완료되면 팝업 뜨지 않음

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -140,7 +140,9 @@ extension ActivityRecordDetailVC {
             self?.deleteRecord()
         }
         
-        [ editAction, deleteAlertAction ].forEach { alertController.addAction($0) }
+        let cancelAction = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
+        
+        [ editAction, deleteAlertAction, cancelAction ].forEach { alertController.addAction($0) }
         present(alertController, animated: true, completion: nil)
     }
     

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -187,7 +187,6 @@ extension ActivityRecordDetailVC {
     
     @objc private func finishEditButtonDidTap() {
         editRecordTitle()
-        showToast(message: "제목 수정이 완료되었어요")
         
         // 수정이 완료되면 팝업 뜨지 않음
         self.navibar.resetLeftButtonAction({ [weak self] in
@@ -516,6 +515,7 @@ extension ActivityRecordDetailVC {
                 let status = result.statusCode
                 if 200..<300 ~= status {
                     print("제목 수정 성공")
+                    showToast(message: "제목 수정이 완료되었어요")
                 }
                 if status >= 400 {
                     print("400 error")

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
@@ -227,7 +227,8 @@ extension ActivityRecordInfoVC {
         }
         
         emptyView.snp.makeConstraints { make in
-            make.center.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.centerY.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview().inset(80)
         }
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
@@ -229,7 +229,8 @@ extension UploadedCourseInfoVC {
             make.leading.bottom.trailing.equalToSuperview()
         }
         emptyView.snp.makeConstraints { make in
-            make.center.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.centerY.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview().inset(80)
         }
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/SettingVC/SettingVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/SettingVC/SettingVC.swift
@@ -26,7 +26,7 @@ final class SettingVC: UIViewController {
     let reportUrl = NSURL(string: "https://docs.google.com/forms/d/e/1FAIpQLSek2rkClKfGaz1zwTEHX3Oojbq_pbF3ifPYMYezBU0_pe-_Tg/viewform")
     lazy var reportSafariView: SFSafariViewController = SFSafariViewController(url: self.reportUrl! as URL)
     
-    let termsOfServiceUrl = NSURL(string: "https://www.notion.so/Runnect-81cf5a3a507b40e4b6104b5d08f12792?pvs=4")
+    let termsOfServiceUrl = NSURL(string: "https://third-sight-046.notion.site/Runnect-5dfee19ccff04c388590e5ee335e77ed")
     lazy var termsOfServiceSafariView: SFSafariViewController = SFSafariViewController(url: self.termsOfServiceUrl! as URL)
     
     private lazy var personalInfoView = makeInfoView(title: "계정 정보").then {


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 현재 발견된 버그들을 수정했습니다.

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 피그마 상 UI와 달라보이는 부분들의 레이아웃 간격 등을 작게 수정했습니다.
- 코스 공유 -> 상세 페이지 -> 내가 올린 코스일 경우 수정 페이지: 완료 버튼 눌렀을 때 api 요청을 보내고, 저장 없이 뒤로가기를 할 경우 alert 팝업이 뜨도록 코드를 수정했습니다. 또한, 같은 코스에 대하여 두 번 수정이 불가능한 부분, 완료 버튼 활성화 로직을 수정했습니다.
- 코스 공유 -> 상세 페이지: 알 수 없음 유저에 대해서 UI가 다르게 보일 수 있도록 수정했습니다.
- 내 러닝 기록 수정에서 api 요청이 제대로 되지 않아 확인해보니, 해당 함수를 테스트용으로 주석 처리 해놓은 것을 해제하지 않아 생기 ㄴ문제였습닏다.. (ㅋ)

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 코스 공유  | <img src = "https://github.com/Runnect/Runnect-iOS/assets/79050615/81215d60-e23d-4be7-9b38-6e17c5337a81" width = 300>  |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #154 
