### PR TITLE
[Fix] #165 - isEditMode 버튼 토글 및 activityRecordList 초기화 문제 해결

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Global/UIComponents/RNAlertVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Global/UIComponents/RNAlertVC.swift
@@ -15,7 +15,7 @@ final class RNAlertVC: UIViewController {
     // MARK: - Properties
     
     var rightButtonTapAction: (() -> Void)?
-    
+        
     var deleteRecordDelegate: deleteRecordDelegate?
         
     // MARK: - UI Components

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordInfoVC.swift
@@ -127,6 +127,8 @@ extension ActivityRecordInfoVC {
 
 extension ActivityRecordInfoVC {
     func wantsToDelete() {
+        self.deleteRecordList = [Int]()
+        
         print("삭제 실행")
         
         guard let selectedRecords = activityRecordTableView.indexPathsForSelectedRows else { return }
@@ -135,6 +137,7 @@ extension ActivityRecordInfoVC {
             self.deleteRecordList.append(activityRecordList[indexPath.row].id)
         }
         
+        self.isEditMode.toggle()
         deleteRecord()
     }
 }
@@ -143,6 +146,7 @@ extension ActivityRecordInfoVC {
 
 extension ActivityRecordInfoVC {
     @objc func editButtonDidTap() {
+        print(isEditMode)
         if isEditMode {
             self.totalNumOfRecordlabel.text = "총 기록 \(self.activityRecordList.count)개"
             self.editButton.setTitle("편집", for: .normal)
@@ -168,6 +172,9 @@ extension ActivityRecordInfoVC {
         self.present(deleteAlertVC, animated: false, completion: nil)
         deleteAlertVC.rightButtonTapAction = { [weak self] in
             deleteAlertVC.dismiss(animated: false)
+            let activityRecordInfoVC = ActivityRecordInfoVC()
+            activityRecordInfoVC.isEditMode = false
+            return
         }
     }
 }


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- isEditMode 버튼 토글 및 activityRecordList 초기화 문제 해결

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 삭제 이후 activityRecordList을 초기화해주지 않아서.. 삭제할 레코드가 계속 쌓여 두 번 이상 삭제가 안 됏던 것이엇습니다
- 하다보니 편집 버튼 토글이 이상해서.. . (삭제 Alert가 사용자 취소에 의해 dismiss 되었을 때) 로직을 수정했습니다

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
생략

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #165 
