### PR TITLE
[Feat] #167 - fastlane 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ iOSInjectionProject/
 # End of https://www.toptal.com/developers/gitignore/api/xcode,swift,cocoapods
 .DS_Store
 Config.swift
+Gemfile.lock
+report.xml
+Runnect-iOS/fastlane/.env

--- a/.gitignore
+++ b/.gitignore
@@ -111,4 +111,4 @@ iOSInjectionProject/
 Config.swift
 Gemfile.lock
 report.xml
-Runnect-iOS/fastlane/.env
+Runnect-iOS/fastlane/.env.default

--- a/Runnect-iOS/Gemfile
+++ b/Runnect-iOS/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
+++ b/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
@@ -1625,7 +1625,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.runnect.Runnect-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Runnect Debug";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.runnect.Runnect-iOS";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1666,7 +1666,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.runnect.Runnect-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Runnect Release";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.runnect.Runnect-iOS";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
+++ b/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
@@ -1604,7 +1604,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Runnect-iOS/Runnect-iOS.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 23053001;
+				CURRENT_PROJECT_VERSION = 2023.0703.2201;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9K86FQHDLU;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1622,7 +1622,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.runnect.Runnect-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1633,6 +1633,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
 		};
@@ -1645,7 +1646,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Runnect-iOS/Runnect-iOS.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 23053001;
+				CURRENT_PROJECT_VERSION = 2023.0703.2201;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9K86FQHDLU;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1663,7 +1664,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.runnect.Runnect-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1674,6 +1675,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
 		};

--- a/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
+++ b/Runnect-iOS/Runnect-iOS.xcodeproj/project.pbxproj
@@ -1604,10 +1604,9 @@
 				CODE_SIGN_ENTITLEMENTS = "Runnect-iOS/Runnect-iOS.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2023.0703.2201;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9K86FQHDLU;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Runnect-iOS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Runnect;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "코스 출발지 설정과 러닝 트래킹을 위해 현재 위치 정보를 사용하도록 허용합니다.";
@@ -1646,10 +1645,9 @@
 				CODE_SIGN_ENTITLEMENTS = "Runnect-iOS/Runnect-iOS.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2023.0703.2201;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9K86FQHDLU;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Runnect-iOS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Runnect;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "코스 출발지 설정과 러닝 트래킹을 위해 현재 위치 정보를 사용하도록 허용합니다.";

--- a/Runnect-iOS/Runnect-iOS/Info.plist
+++ b/Runnect-iOS/Runnect-iOS/Info.plist
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Runnect</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.1.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -13,11 +29,21 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>2023.0703.2210</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>
 		<string>kakaolink</string>
 	</array>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>코스 출발지 설정과 러닝 트래킹을 위해 현재 위치 정보를 사용하도록 허용합니다.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>코스 출발지 설정과 러닝 트래킹을 위해 현재 위치 정보를 사용하도록 허용합니다.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>코스 출발지 설정과 러닝 트래킹을 위해 현재 위치 정보를 사용하도록 허용합니다.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>
@@ -42,5 +68,24 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Runnect-iOS/Runnect-iOS/Info.plist
+++ b/Runnect-iOS/Runnect-iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2023.0703.2210</string>
+	<string>2023.0703.2250</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/Runnect-iOS/fastlane/Appfile
+++ b/Runnect-iOS/fastlane/Appfile
@@ -1,0 +1,8 @@
+app_identifier("com.runnect.Runnect-iOS") # The bundle identifier of your app
+apple_id(ENV["APPLE_ID"]) # Your Apple Developer Portal username
+
+itc_team_id("125287287") # App Store Connect Team ID
+team_id("9K86FQHDLU") # Developer Portal Team ID
+
+# For more information about the Appfile, see:
+#     https://docs.fastlane.tools/advanced/#appfile

--- a/Runnect-iOS/fastlane/Fastfile
+++ b/Runnect-iOS/fastlane/Fastfile
@@ -28,4 +28,48 @@ platform :ios do
       xcodeproj: "./Runnect-iOS.xcodeproj"
     )
   end
+
+  desc "Testflight Upload"
+  lane :upload_testflight do |version|
+    version = version[:version]
+
+    match(
+      type: "appstore",
+      app_identifier: "com.runnect.Runnect-iOS",
+      readonly: true
+    )
+
+    if version
+      puts "버전 정보: #{version}"
+      set_version(version: version)
+    else 
+      puts "버전 입력 X"
+      increment_build_number(
+        build_number: Time.new.strftime("%Y.%m%d.%H%M"),
+        xcodeproj: "./Runnect-iOS.xcodeproj"
+      )
+    end
+
+    build_app(
+      output_directory:"./BuildOutputs",
+      scheme: "Runnect-iOS"
+    )
+
+    upload_to_testflight(skip_waiting_for_build_processing: true)
+  end
+
+  desc "Match all code signing"
+  lane :match_read_only do
+    match(
+      type: "appstore",
+      app_identifier: "com.runnect.Runnect-iOS",
+      readonly: true
+    )
+
+    match(
+      type: "development",
+      app_identifier: "com.runnect.Runnect-iOS",
+      readonly: true
+    )
+  end
 end

--- a/Runnect-iOS/fastlane/Fastfile
+++ b/Runnect-iOS/fastlane/Fastfile
@@ -1,0 +1,31 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+default_platform(:ios)
+
+platform :ios do
+  desc "Set Marketing and Build version"
+  lane :set_version do |version|
+    increment_version_number(
+      version_number: version[:version],
+      xcodeproj: "./Runnect-iOS.xcodeproj"
+    )
+  
+    increment_build_number(
+      build_number: Time.new.strftime("%Y.%m%d.%H%M"), # 2023.0703.2100
+      xcodeproj: "./Runnect-iOS.xcodeproj"
+    )
+  end
+end

--- a/Runnect-iOS/fastlane/Matchfile
+++ b/Runnect-iOS/fastlane/Matchfile
@@ -1,0 +1,15 @@
+git_url("git@github.com:lsj8706/fastlane-match.git")
+git_branch("runnect")
+
+storage_mode("git")
+
+type("appstore") # The default type, can be: appstore, adhoc, enterprise or development
+
+app_identifier(["com.runnect.Runnect-iOS"])
+
+# username("user@fastlane.tools") # Your Apple Developer Portal username
+
+# For all available options run `fastlane match --help`
+# Remove the # in the beginning of the line to enable the other options
+
+# The docs are available on https://docs.fastlane.tools/actions/match

--- a/Runnect-iOS/fastlane/README.md
+++ b/Runnect-iOS/fastlane/README.md
@@ -1,0 +1,32 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## iOS
+
+### ios set_version
+
+```sh
+[bundle exec] fastlane ios set_version
+```
+
+Set Marketing and Build version
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/Runnect-iOS/fastlane/README.md
+++ b/Runnect-iOS/fastlane/README.md
@@ -23,6 +23,22 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Set Marketing and Build version
 
+### ios upload_testflight
+
+```sh
+[bundle exec] fastlane ios upload_testflight
+```
+
+Testflight Upload
+
+### ios match_read_only
+
+```sh
+[bundle exec] fastlane ios match_read_only
+```
+
+Match all code signing
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
## 🌱 작업한 내용

- fastlane을 도입했습니다
- 이제 fastlane match를 통해 쉽게 인증서 관리가 가능합니다.
- 새로운 팀원이 왔을 때 저번처럼 카톡으로 제가 인증서를 드리지 않아도 본인이 직접 터미널에 명령어를 입력하면 Github private 레포지토리에 제가 올려둔 인증서들이 자동으로 다운로드 되는 원리입니다.

## 🌱 PR Point

- fastlane은 CI/CD 툴입니다. [참고](https://docs.fastlane.tools/#)
- lane 명령어를 생성하고 fastlane에서 제공하는 함수들을 활용하여 원하는 기능을 구현할 수 있습니다.

### 생성한 lane
- 인증서를 다운받는 `match_read_only`
- 프로젝트 버전을 설정하는 `set_version`
- 테스트플라이트 업로드를 해주는 `upload_testflight`
이렇게 3가지를 만들어 두었으며 필요하다면 추가적으로 만들어서 사용하시면 됩니다!!
지금은 인증서를 최신화하는 `match_read_only`만 사용해도 무관합니다.

### 머지 후 각자 해야 할 일
우선 Github ssh 등록은 안했다면 등록 해주세요 [가이드](https://docs.github.com/ko/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)

[Fastlane 공식 가이드 참고](https://docs.fastlane.tools/getting-started/ios/setup/)
1. 터미널 켜서 Runnect 프로젝트 폴더로 이동
2. `xcode-select --install` 실행
3. fastlane 설치 -> 공식 문서에서는 Bundler를 사용해 설치하는 것을 권장하는데 이렇게 하니까 fastlane 명령어를 실행할 때 앞에 bundle exec를 붙여야 해서 저는 brew로 설치했습니다. 각자 편한 방식으로 하면 될 것 같아요! `brew install fastlane`
4. fastlane 폴더가 있을텐데 거기로 이동해서 .env.default 파일 생성하고 제가 따로 전달할 코드들을 이 파일에 붙여넣기
5. 터미널에서 프로젝트 파일이 있는 경로로 이동
6. `fastlane match_read_only`실행 -> 이렇게 하면 자동으로 깃헙에 올라가 있는 인증서들 다운로드 진행
7. 만약 passphrase를 입력하라고 하면 카톡으로 전달한 비번 입력
8. 키체인 password 입력하라고 하면 각자 노트북 비번 입력
9. 여기까지 성공 했으면 Xcode로 프로젝트 켜서 인증서가 match 어쩌고~~로 잘 들어가 있는지 확인!!!!

여기까지 하면 세팅 + 실행 확인까지 잘 된거에요!
하다가 잘 안되는 부분 있으면 언제든 연락 주시면 됩니다!

## 추가적인 lane 사용법
앞서 3가지 lane을 생성했다고 했는데 이것들은 Fastfile에 들어가면 Ruby라는 언어로 작성되어 있습니다.
만들어둔 3가지 lane에 대한 설명을 첨부합니다. (터미널에 아래와 같이 입력하면 실행됩니다!)
- `fastlane set_version version:2.1.5`: 이렇게 하면 우리 프로젝트 버전이 2.1.5로 자동 변경됩니다.
- `fastlane upload_testflight version:2.1.5`: 2.1.5로 버전 설정후 테스트플라이트 자동 업로드 (인증서도 최신화 자동으로 합니다.)
- `fastlane match_read_only`: 인증서 최신화


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #167 
