### PR TITLE
[Fix] #184 - Xcode 15 버전 코드 수정

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Global/Utils/setImage.swift
+++ b/Runnect-iOS/Runnect-iOS/Global/Utils/setImage.swift
@@ -32,7 +32,7 @@ public extension UIImageView {
     
     private func setNewImage(with urlString: String, placeholder: String? = "img_placeholder", completion: ((UIImage?) -> Void)? = nil) {
         guard let url = URL(string: urlString) else { return }
-        let resource = ImageResource(downloadURL: url, cacheKey: urlString)
+        let resource = Kingfisher.KF.ImageResource(downloadURL: url, cacheKey: urlString)
         let placeholderImage = UIImage(named: "img_placeholder")
         let placeholder = placeholderImage
         

--- a/Runnect-iOS/Runnect-iOS/Info.plist
+++ b/Runnect-iOS/Runnect-iOS/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 작업 내용 1

Xcode 가 15로 버전업 되면서 원래 코드가 디버깅이 안됩니다.
그래서 약간 수정을 하였습니다.
Xcode 14.x 버전에서도 돌아가니 꼭 업데이트 안하셔도됩니다.

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- ATS(App Transport Sercurity) 문제 -> info.plist 수정

    <img width="581" alt="image" src="https://github.com/Runnect/Runnect-iOS/assets/88179341/f34820f2-1fff-440b-9c6f-20c435841397">


- Kingfisher -> 명확하게 어떤 클래스인지 수정

    링크 참고
    https://thingjin.tistory.com/entry/iOS-Xcode-15-Kingfisher-%EC%97%90%EC%84%9C%EC%9D%98-ImageResource-%EC%9D%B4%EC%8A%88-%ED%95%B4%EA%B2%B0

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

info.plist
<img width="581" alt="image" src="https://github.com/Runnect/Runnect-iOS/assets/88179341/b5637600-bb14-4754-a974-5d50ece3467d">

파일에는 소스로 보여서 뭐가 바뀐지 모를텐데 저 부분을 추가 했어요!


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #184 
