### PR TITLE
[Feat] #183 - 코스 발견 pagination

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Network/Router/PublicCourseRouter.swift
+++ b/Runnect-iOS/Runnect-iOS/Network/Router/PublicCourseRouter.swift
@@ -9,7 +9,7 @@ import Foundation
 import Moya
 
 enum PublicCourseRouter {
-    case getCourseData
+    case getCourseData(pageNo: Int)
     case getCourseSearchData(keyword: String)
     case courseUploadingData(param: CourseUploadingRequestDto)
     case getUploadedCourseDetail(publicCourseId: Int)
@@ -59,6 +59,8 @@ extension PublicCourseRouter: TargetType {
     
     var task: Moya.Task {
         switch self {
+        case .getCourseData(let pageNo):
+            return .requestParameters(parameters: ["pageNo": pageNo], encoding: URLEncoding.default)
         case .getCourseSearchData(let keyword):
             return .requestParameters(parameters: ["keyword": keyword], encoding: URLEncoding.default)
         case .courseUploadingData(param: let param):
@@ -73,7 +75,7 @@ extension PublicCourseRouter: TargetType {
                 fatalError("Encoding 실패")}
         case .deleteUploadedCourse(let publicCourseIdList):
             return .requestParameters(parameters: ["publicCourseIdList": publicCourseIdList], encoding: JSONEncoding.default)
-        case .getCourseData, .getUploadedCourseDetail, .getUploadedCourseInfo:
+        case .getUploadedCourseDetail, .getUploadedCourseInfo:
             return .requestPlain
         }
     }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDiscovery/Views/VC/CourseDiscoveryVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDiscovery/Views/VC/CourseDiscoveryVC.swift
@@ -230,7 +230,7 @@ extension CourseDiscoveryVC: UICollectionViewDelegate, UICollectionViewDataSourc
         
         // 스크롤이 맨 아래에 도달하면 다음 페이지 데이터를 불러옵니다.
         if contentOffsetY >= collectionViewHeight - paginationY {
-            if courseList.count < pageNo * 12 { // 페이지 끝에 도달하면 현재 페이지에 더 이상 데이터가 없음을 의미합니다.
+            if courseList.count < pageNo * 24 { // 페이지 끝에 도달하면 현재 페이지에 더 이상 데이터가 없음을 의미합니다.
                 // 페이지네이션 중단 코드
                 return
             }

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDiscovery/Views/VC/CourseDiscoveryVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDiscovery/Views/VC/CourseDiscoveryVC.swift
@@ -21,8 +21,10 @@ final class CourseDiscoveryVC: UIViewController {
     
     private var courseList = [PublicCourse]()
     
-    // pagenation 을 위한 변수 입니다.
+    // pagination 에 꼭 필요한 위한 변수들 입니다.
     private var pageNo = 1
+    
+    private var isDataLoaded = false
     
     // MARK: - UIComponents
     
@@ -69,15 +71,8 @@ final class CourseDiscoveryVC: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        // 데이터 초기화
-        courseList.removeAll()
-        pageNo = 1
-
-        // 컬렉션 뷰를 리로드하여 초기화된 데이터를 화면에 표시
-        mapCollectionView.reloadData()
         self.hideTabBar(wantsToHide: false)
-        self.getCourseData()
+        setDataLoadIfNeeded()
     }
 }
 
@@ -106,6 +101,22 @@ extension CourseDiscoveryVC {
     private func setAddTarget() {
         self.searchButton.addTarget(self, action: #selector(pushToSearchVC), for: .touchUpInside)
         self.uploadButton.addTarget(self, action: #selector(pushToDiscoveryVC), for: .touchUpInside)
+    }
+    
+    private func setDataLoadIfNeeded() { /// 데이터를 받고 다른 뷰를 갔다가 와도 데이터가 유지되게끔 하기 위한 함수 입니다. (한번만 호출되면 되는 함수!)
+        if !isDataLoaded {
+            // 앱이 실행 될때 처음에만 데이터 초기화
+            courseList.removeAll()
+            pageNo = 1
+
+            // 컬렉션 뷰를 리로드하여 초기화된 데이터를 화면에 표시
+            mapCollectionView.reloadData()
+            self.getCourseData()
+            
+            isDataLoaded = true // 데이터가 로드되었음을 표시
+        } else {
+            return
+        }
     }
 }
 

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDiscovery/Views/VC/CourseDiscoveryVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDiscovery/Views/VC/CourseDiscoveryVC.swift
@@ -225,10 +225,10 @@ extension CourseDiscoveryVC: UICollectionViewDelegate, UICollectionViewDataSourc
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let contentOffsetY = scrollView.contentOffset.y
-        let collectionViewHeight = scrollView.contentSize.height
+        let collectionViewHeight = mapCollectionView.contentSize.height
         let paginationY = collectionViewHeight * 0.2
         
-        // 스크롤이 맨 아래에 도달하면 다음 페이지 데이터를 불러옵니다.
+        // 스크롤이 80% (0.2)  까지 도달하면 다음 페이지 데이터를 불러옵니다.
         if contentOffsetY >= collectionViewHeight - paginationY {
             if courseList.count < pageNo * 24 { // 페이지 끝에 도달하면 현재 페이지에 더 이상 데이터가 없음을 의미합니다.
                 // 페이지네이션 중단 코드


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- ⭐️코스 발견의 데이터 받아오는 API 가 변경되는 것⭐️ 이 있었습니다.
그에 맞게 라우터 수정과 Pagination 로직을 추가 했습니다.
- PublicCourseRouter.getCourseData 에 parameter `pageNo` 추가
저희 API를 보시면 디폴트가 pageNo = 1 로 수정 되었고 직접 추가를 해줘야하기 때문에 변경 하였습니다.
- `scrollViewDidScroll()` 메서드 추가 ⭐️⭐️
- `viewWillAppear()` 로직 추가


## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 이해 안 되는 부분이 있을까봐 주석을 달아 놨습니다.
코드 리뷰 후 정말 필요하다 싶은 것 빼고는 주석 지우고 머지 할 생각입니다.
- `Pagination` 의 로직을 구현했는데 아래 블로그에 정리해놨습니다
이해 안 될 수도 있는데 안된다면 따로 디스코드 요청 바랍니다!
[Pagination 정리](https://thingjin.tistory.com/entry/iOS-%EB%8D%B0%EC%9D%B4%ED%84%B0-%ED%8E%98%EC%9D%B4%EC%A7%95-Pagination-in-UIKit-ColletionView)

- 요약
courseList 의 전체 개수가 pageNo x 24 보다 작다면 데이터를 다 불러왔다고 생각하여 페이지네이션을 끝내는 로직을 구현 했습니다.
24를 곱한 이유는 우리의 API 가 page 당 24개씩 불러오기 때문입니다.
괜찮은 로직이 생각나면 리뷰 부탁드립니다.


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 🕒 페이징 도입 전 | 🕓 페이징 도입 후 |
| :-------------: | :----------: |
| ![전](https://github.com/Runnect/Runnect-iOS/assets/88179341/bfdd363b-6378-4cc7-bed9-5b444c287b58)  | ![후](https://github.com/Runnect/Runnect-iOS/assets/88179341/acf9a5ee-b983-41e5-9618-209c85623d52) |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #183 
