### PR TITLE
[Fix] #196 - 코스 삭제 이벤트 시점을 수정 하였습니다.

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
@@ -556,7 +556,9 @@ extension CourseDetailVC {
                 deleteAlertVC.rightButtonTapAction = {
                     deleteAlertVC.dismiss(animated: false)
                     self.deleteCourse()
-                    self.navigationController?.popViewController(animated: true)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        self.navigationController?.popViewController(animated: true)
+                    }
                 }
                 self.present(deleteAlertVC, animated: false)
             case "신고하기":

--- a/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/CourseDetail/VC/CourseDetailVC.swift
@@ -517,6 +517,9 @@ extension CourseDetailVC {
                 let status = result.statusCode
                 if 200..<300 ~= status {
                     print("삭제 성공")
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        self.navigationController?.popViewController(animated: true)
+                    }
                 }
                 if status >= 400 {
                     print("400 error")
@@ -556,9 +559,6 @@ extension CourseDetailVC {
                 deleteAlertVC.rightButtonTapAction = {
                     deleteAlertVC.dismiss(animated: false)
                     self.deleteCourse()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        self.navigationController?.popViewController(animated: true)
-                    }
                 }
                 self.present(deleteAlertVC, animated: false)
             case "신고하기":

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/UploadedCourseInfoVC.swift
@@ -100,6 +100,7 @@ final class UploadedCourseInfoVC: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.hideTabBar(wantsToHide: true)
+        getUploadedCourseInfo()
     }
 }
 


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 나의 업로드한 코스 삭제 기능을 사용했을때, 
`삭제 -> 뷰 새로고침` 으로 로직이 되어야하는데
`뷰 새로고침 -> 삭제` 순서가 되어버려서 나의 업로드한 코스가 새로고침이 안되는 오류가 발생 하였습니다. 
(이벤트 시점 문제)
- 삭제 후 뷰 이동이 안되는 부분도 해결하였습니다 -> #192 

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- deleteCourse에 동기 처리로 0.1초의 텀을 두었습니다.
- 또한 DispatchQueue.main.asyncAfter() 쓰는 게 좋은 코드인지? 생각해 봐야겠습니다.

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

- ❌ ver 2.0.0 전 (코스 1개 삭제 시 코스 1개 그대로 남아 있고 뷰 이동도 처리되지 않음)
(UI도 업데이트전 ^^..)

https://github.com/Runnect/Runnect-iOS/assets/88179341/1a682c09-336c-4d9a-8ddb-28b3ccfe0be3 

---

- ✅ ver 2.0.0 후 ( 코스 2개 에서 1개 새로고침 + 뷰 이동 처리 )

https://github.com/Runnect/Runnect-iOS/assets/88179341/1a1c051a-00b0-4781-b3cd-dc32bbaa2f2f 





## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #196 
