### PR TITLE
[Feat] #212 - 러닝 기록 상세페이지 메뉴 변경

### DIFF
--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -44,12 +44,10 @@ final class ActivityRecordDetailVC: UIViewController {
     }
     
     private lazy var courseTitleTextField = UITextField().then {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = .center
         
         $0.attributedPlaceholder = NSAttributedString(
             string: "글 제목",
-            attributes: [.font: UIFont.h4, .foregroundColor: UIColor.g3, .paragraphStyle: paragraphStyle]
+            attributes: [.font: UIFont.h4, .foregroundColor: UIColor.g3]
         )
         $0.font = .h4
         $0.textColor = .g1
@@ -199,7 +197,7 @@ extension ActivityRecordDetailVC {
     @objc private func finishEditButtonDidTap() {
         editRecordTitle()
         
-        // 키보드가 올라와 있을때 내려가는 코드 추가
+        // 키보드가 올라와 있다면 내려가는 코드 추가
         view.endEditing(true)
         
         // 수정이 완료되면 팝업 뜨지 않음

--- a/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
+++ b/Runnect-iOS/Runnect-iOS/Presentation/MyPage/VC/InfoVC/ActivityRecordDetailVC.swift
@@ -43,15 +43,18 @@ final class ActivityRecordDetailVC: UIViewController {
         $0.font = .h4
     }
     
-    private let courseTitleTextField = UITextField().then {
-        $0.resignFirstResponder()
+    private lazy var courseTitleTextField = UITextField().then {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+        
         $0.attributedPlaceholder = NSAttributedString(
             string: "글 제목",
-            attributes: [.font: UIFont.h4, .foregroundColor: UIColor.g3]
+            attributes: [.font: UIFont.h4, .foregroundColor: UIColor.g3, .paragraphStyle: paragraphStyle]
         )
         $0.font = .h4
         $0.textColor = .g1
         $0.addLeftPadding(width: 2)
+        $0.addTarget(self, action: #selector(textFieldTextDidChange), for: .editingChanged)
     }
     
     private let recordDateInfoView = CourseDetailInfoView(title: "날짜", description: String())
@@ -71,7 +74,7 @@ final class ActivityRecordDetailVC: UIViewController {
     private lazy var recordDistanceLabel = SetInfoLayout.makeGreySmailTitleLabel().then {
         $0.text = "거리"
     }
-
+    
     private lazy var recordRunningTimeLabel = SetInfoLayout.makeGreySmailTitleLabel().then {
         $0.text = "이동 시간"
     }
@@ -79,7 +82,7 @@ final class ActivityRecordDetailVC: UIViewController {
     private lazy var recordAveragePaceLabel = SetInfoLayout.makeGreySmailTitleLabel().then {
         $0.text = "평균 페이스"
     }
-
+    
     private lazy var recordDistanceValueLabel = SetInfoLayout.makeBlackTitleLabel()
     
     private lazy var recordRunningTimeValueLabel = SetInfoLayout.makeBlackTitleLabel()
@@ -211,6 +214,7 @@ extension ActivityRecordDetailVC {
             make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
             make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
+        
     }
     
     @objc private func presentToQuitEditAlertVC() {
@@ -315,8 +319,11 @@ extension ActivityRecordDetailVC {
 
 extension ActivityRecordDetailVC: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
         if textField == self.courseTitleTextField {
-            self.finishEditButtonDidTap()
+            if finishEditButton.isEnabled == true {
+                self.finishEditButtonDidTap()
+            }
         }
         return true
     }
@@ -427,7 +434,7 @@ extension ActivityRecordDetailVC {
     
     private func setEditMode() {
         self.navibar.isHidden = false // true
-
+        
         mapImageView.snp.remakeConstraints { make in
             make.top.equalToSuperview()
             make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
@@ -439,13 +446,13 @@ extension ActivityRecordDetailVC {
         self.courseTitleTextField.text = self.courseTitleLabel.text
         
         middleScorollView.addSubview(courseTitleTextField)
-                
+        
         courseTitleTextField.snp.makeConstraints { make in
             make.top.equalTo(mapImageView.snp.bottom).offset(27)
             make.leading.trailing.equalToSuperview().inset(16)
             make.height.equalTo(35)
         }
-    
+        
         self.finishEditButton.isHidden = false
         
         firstHorizontalDivideLine.snp.remakeConstraints { make in
@@ -469,9 +476,9 @@ extension ActivityRecordDetailVC {
             make.top.equalTo(secondHorizontalDivideLine.snp.bottom).offset(22)
             make.centerX.equalToSuperview()
         }
-                
+        
         middleScorollView.addSubview(finishEditButton)
-
+        
         finishEditButton.snp.makeConstraints { make in
             make.bottom.equalToSuperview().inset(30)
             make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(16)
@@ -526,6 +533,7 @@ extension ActivityRecordDetailVC {
                 if 200..<300 ~= status {
                     print("제목 수정 성공")
                     self.showToast(message: "제목 수정이 완료되었어요")
+                    self.finishEditButton.isEnabled = false
                 }
                 if status >= 400 {
                     print("400 error")


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 드롭 다운으로 메뉴 변경
- 예전 코드 약간 수정
    - 키보드 안올라가는 이슈
    - 키보드 관련 로직 추가 

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 텍스트 필드의 텍스트(`TextField.text`)를 눌러야 `.editingChanged` 가 되는데.. 왜 텍스트 필드를 누르면 안 될까요..? ,, 기존 코드의 어떤 문제점이 있을지 ... !?
- 기존 코드에서 키보드를 안 올린 것 이 일부러 안 올린 건지..? 궁금하네요,,, 
    - 어떻게 생각하시는지?? ㅎㅎ

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 러닝 기록 상세 페이지 | <img src="https://github.com/Runnect/Runnect-iOS/assets/88179341/84bda5e9-c806-441f-a2a6-04eb5296b547" width="195" height="422"> |
## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #212 
